### PR TITLE
add Datastore Tracking

### DIFF
--- a/.github/workflows/action_datastore_tracker.yml
+++ b/.github/workflows/action_datastore_tracker.yml
@@ -22,7 +22,8 @@ jobs:
 
       - name: Run script
         working-directory: datastore_tracker    
-        run: ds_tracker.py
+        run: |
+          python ds_tracker.py
 
       - name: Commit CSV
         working-directory: datastore_tracker    

--- a/.github/workflows/action_datastore_tracker.yml
+++ b/.github/workflows/action_datastore_tracker.yml
@@ -1,0 +1,34 @@
+name: Update CKAN Datastore Stats
+on:
+  schedule:
+    - cron: '10 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install requests pandas ujson
+
+      - name: Run script
+        working-directory: datastore_tracker    
+        run: ds_tracker.py
+
+      - name: Commit CSV
+        working-directory: datastore_tracker    
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add DS_num_tracker.csv ds-resources.csv
+          git commit -m "Auto-update DS_num_tracker.csv [skip ci]"
+          git push

--- a/datastore_tracker/DS_num_tracker.csv
+++ b/datastore_tracker/DS_num_tracker.csv
@@ -1,0 +1,2 @@
+date,num_dept,num_datasets,num_res,ds_size_readable
+2024-12-27,36,779,2251,111.8GB

--- a/datastore_tracker/ds-resources.csv
+++ b/datastore_tracker/ds-resources.csv
@@ -1,0 +1,2252 @@
+owner,package_id,dataset_name,resource_id,resource_name,size
+cbsa-asfc,000fe5aa-1d77-42d1-bfe7-458c51dacfef,Historical Border Wait Times – Land Mode,2b5853e4-41b4-4858-86dd-38012e30d5b8,Historical Border Wait Times - 2019-04-01 to 2024-10-31,74010
+cbsa-asfc,000fe5aa-1d77-42d1-bfe7-458c51dacfef,Historical Border Wait Times – Land Mode,c38762fc-3185-4cc7-9669-89ae2f9b5069,Historical Border Wait Time - 2019-04-01 to 2024-10-31,73921
+psc-cfp,00887ede-ac6b-47c1-af0c-aea61f2be345,Public Service Commission (PSC) Departmental Results Framework Indicators,15dffa94-0066-493a-808b-377cfa6e5c34,Indicator I1 – Number of Days to complete an external staffing process,2388
+psc-cfp,00887ede-ac6b-47c1-af0c-aea61f2be345,Public Service Commission (PSC) Departmental Results Framework Indicators,78eda841-ae3f-4235-a517-2a9b6ed48bb5,Indicator I9 – Percentage of new hires under the age of 35,63940
+psc-cfp,00887ede-ac6b-47c1-af0c-aea61f2be345,Public Service Commission (PSC) Departmental Results Framework Indicators,1f079599-21e4-4e34-be00-228e57976506,Indicator I11 – Percentage of new hires who applied from outside the National Capital Region,4476
+tbs-sct,009f9a49-c2d9-4d29-a6d4-1a228da335ce,Proactive Disclosure - Travel Expenses,8282db2a-878f-475c-af10-ad56aa8fa72c,Proactive Disclosure - Travel Expenses,58585264
+tbs-sct,009f9a49-c2d9-4d29-a6d4-1a228da335ce,Proactive Disclosure - Travel Expenses,d3f883ce-4133-48da-bc76-c6b063d257a2,Proactive Disclosure - Travel Expenses Nothing to Report,252887
+csa-asc,0176458c-553b-48b4-a5e2-492022c81e85,The Geospace Observatory (GO) Canada Initiative,b335e213-16e9-4755-8125-a22b55319cb5,GO_Canada_Carte_Data_FR,19622
+csa-asc,0176458c-553b-48b4-a5e2-492022c81e85,The Geospace Observatory (GO) Canada Initiative,8d5b21aa-f5b6-4586-9b2b-5ac44779b66a,GO_Canada_Map_Data_EN,19331
+esdc-edsc,01c0f9da-f52d-4436-9899-f375b905e481,"Canadian Citizen and Permanent Resident Workforce Population by Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",2f76d34f-308d-48aa-b851-70df5108d3a0,"Canadian Citizen and Permanent Resident Workforce Representation by 4 Designated Groups by Canada, Provinces, Territories and Census Metropolitan Areas",5907
+esdc-edsc,01c0f9da-f52d-4436-9899-f375b905e481,"Canadian Citizen and Permanent Resident Workforce Population by Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",118738d9-482a-4415-afab-03d25111831a,"Canadian Citizen and Permanent Resident Workforce Representation by 4 Designated Groups by Canada, Provinces, Territories and Census Metropolitan Areas",5278
+esdc-edsc,01c0f9da-f52d-4436-9899-f375b905e481,"Canadian Citizen and Permanent Resident Workforce Population by Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",c1a6fb7c-8f89-4e0a-8c19-20deb2886e0f,"Canadian Citizen and Permanent Resident Workforce Population by 3 Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups ",5354285
+esdc-edsc,01c0f9da-f52d-4436-9899-f375b905e481,"Canadian Citizen and Permanent Resident Workforce Population by Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",a2862214-c743-4a2c-a86c-27f6c7f4ac9c,"Canadian Citizen and Permanent Resident Workforce Population by 3 Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups ",4401246
+pc,02410da8-98c7-40fd-8a5b-1bf7dc78eb9a,PAD vegetation change - Wood Buffalo National Park,7b7cc319-b883-4ad3-bb82-e40f1e9fe713,PAD vegetation change - Wood Buffalo,3525
+pc,02c92519-0338-4fef-a79e-37e197cbca4a,Downed Wood Debris - Thousand Islands,4607bfd8-b92e-4ccf-80b0-06ea0ca0ca02,Downed Woody Debris - Thousand Islands - Data,206039
+pc,03e38037-e88c-48c8-ad08-0afb73ae6290,Wildlife Mortality - Yoho,6663c40d-0ad8-4551-afa0-10b76add5c44,Wildlife Mortality Data - Yoho,17621
+pc,03e38037-e88c-48c8-ad08-0afb73ae6290,Wildlife Mortality - Yoho,d42d01ea-c4e6-4a8a-8ef8-b501d1d471dd,Wildlife Mortality Data - Yoho - data dictionary,1645
+pc,045239c3-f835-4be8-921a-f17caf264097,Snowshoe hare (pellet survey) - Wood Buffalo,e2263253-0c8d-49dc-88bf-1285e77a74dd,Snowshoe hare (pellet survey) - Wood Buffalo,29289
+pc,045239c3-f835-4be8-921a-f17caf264097,Snowshoe hare (pellet survey) - Wood Buffalo,13031421-f064-49ab-8561-af880f791ae8,Snowshoe hare (pellet survey) - Wood Buffalo - Data dictionary,505
+pc,053f80c2-7ac9-4828-8405-28dae73eb24e,Colonial Waterbirds - Pukaskwa,d2e32a39-5852-4094-b033-79d71f3d9d4e,Colonial Waterbirds - Pukaskwa - Survey Data,239426
+pc,053f80c2-7ac9-4828-8405-28dae73eb24e,Colonial Waterbirds - Pukaskwa,74699df6-a204-4330-b6d2-2c63a7207e69,Colonial Waterbirds - Pukaskwa -  Data Dictionary,1867
+fin,05fbc30f-1228-45a8-9423-ed5cd0f6be7f,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2024",f065f0eb-837b-44c9-b159-fd1da5262618,Data tables - metadata,1998
+fin,05fbc30f-1228-45a8-9423-ed5cd0f6be7f,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2024",0e8eb3c0-891f-4ea8-8184-6632205ac1a2,Data tables - metadata,2357
+fin,05fbc30f-1228-45a8-9423-ed5cd0f6be7f,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2024",dd65b4eb-b356-469b-a7be-312aa37fd970,Data tables,81035
+fin,05fbc30f-1228-45a8-9423-ed5cd0f6be7f,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2024",d0afb02d-9820-4f6c-b37f-b97348abee39,Data tables,104180
+cfia-acia,06033736-6095-4b85-8760-95dd8c209576,2018-2019 Lead Chromates in Spices Data,e21700b3-408d-4ce8-a82b-8bc3023e7242,2018-2019 Lead Chromates in Spices Data,64412
+pc,062bc4bf-604e-442c-917b-19513c9382b6,Brook trout - Kejimkujik,b2e5fc92-15e4-4c9e-9a01-55d1b03d8021,Brook Trout - Kejimkujik -  Creel Census Data - 1,91478
+pc,062bc4bf-604e-442c-917b-19513c9382b6,Brook trout - Kejimkujik,6f410372-44fb-4839-97c6-27e1fd6948ed,Brook Trout - Kejimkujik - Morphometric Data - 2,130596
+pc,062bc4bf-604e-442c-917b-19513c9382b6,Brook trout - Kejimkujik,0db5b9f5-34e6-4a13-9e91-ae780741fbb0,Brook Trout - Kejimkujik - Data Dictionary,3986
+cra-arc,063f225c-4930-4337-a532-ef0e0ba0b30f,"GST/HST Credit statistics by Federal Electoral District – 2019-2020 benefit year, including one-time GST/HST Credit payment",835e0a5b-501b-4732-b977-4281335e9bcf,"GST/HST Credit statistics by Federal Electoral District – 2019-2020 benefit year, including one-time GST/HST Credit payment",19283
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,8199abbe-e318-4869-8b11-fbfc4389129e,Table 1: Number of electors and polling stations,959
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,4acf5ea8-cf65-41c3-a585-d515c7cfdb1a,Table 3: Number of ballots cast and voter turnout,1309
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,3fdbf3de-2b2e-4c44-b32e-98e71cae441b,Table 5: Distribution of valid votes by voting method,1018
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,eeb33c04-8c31-4e4c-896a-754adf28244a,Table 6: Distribution of valid votes under Special Voting Rules,722
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,ee21862c-e718-43d2-bb0c-357b58aafed0,Table 7: Distribution of seats by political affiliation and sex,2697
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,7961f6e7-be2b-48b9-b1c6-914a399990bd,Table 8: Number of valid votes by political affiliation,2918
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,27e9bf7e-b67d-4757-bf63-80aa1c0bc3ee,"Table 10: Number of candidates by percentage of valid votes received, by political affiliation",1791
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,d9ff2144-4591-4ef5-b313-be5012eca3be,Table 11: Voting results by electoral district,47532
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,8d6380a6-c1a3-4a19-b2ca-df0228ab4ddd,Table 12: List of candidates by electoral district and individual results,360118
+elections,065439a9-c194-4259-9c95-245a852be4a1,44th General Election: Official Voting Results,078f13c5-fdc6-4b12-ac88-e46f3f4c8a82,Table 13: List of returning officers,40029
+cfia-acia,0714a84f-b5cf-4d28-b3d2-fd71919b6ecd,CFIA-Undeclared Allergens and Gluten in Candies and Chocolate Products - 2022-2023,54d39bfc-2d1b-4415-b333-537c5f891159,CFIA-Undeclared Allergens and Gluten in Candies and Chocolate Products - 2022-2023,704910
+pc,071dce01-7b0c-4124-a1a3-08216e991d4a,Deer Browse - Summer Herbaceous - Thousand Islands,900533c6-7757-4dff-9f40-04bc5016145a,Deer Browse - Summer Herbaceous - Thousand Islands -Data,28415
+pc,072803b9-0374-44b0-b602-36fb19c52e1c,Forest vegetation community areal extent and distribution - Elk Island,53dfdb9a-1ff0-4edc-be5a-d9dbb39b4324,Forest vegetation community areal extent and distribution - Elk Island,1500
+pc,072803b9-0374-44b0-b602-36fb19c52e1c,Forest vegetation community areal extent and distribution - Elk Island,28341dca-d053-4aef-b624-aa3253fd3879,Forest vegetation community areal extent and distribution - Elk Island - Data dictionary,771
+tbs-sct,0797e893-751e-4695-8229-a5066e4fe43c,Completed Access to Information Request Summaries dataset,19383ca2-b01a-487d-88f7-e1ffbc7d39c2,Completed Access to Information Request Summaries dataset,99116315
+tbs-sct,0797e893-751e-4695-8229-a5066e4fe43c,Completed Access to Information Request Summaries dataset,5a1386a5-ba69-4725-8338-2f26004d7382,Completed Access to Information Request Summaries dataset (Nothing to report),449772
+pc,07c0eed8-2b08-4c0b-b81c-8fed4a6e1d06,Forest Birds - Jasper,52da9d9f-7be4-4077-a4e3-e2fdfd876c4b,Forest Birds - Jasper,666247
+pc,07c0eed8-2b08-4c0b-b81c-8fed4a6e1d06,Forest Birds - Jasper,b1e78c43-5a15-4c12-aa36-191f958d6c66,Forest Birds - Jasper - Data Dictionary,7871
+pc,07c1c8d0-ad43-4411-bb79-278f9f50fb96,Stream Fish Occupancy - Banff,96860bd7-633b-4e6e-967a-c31341fd1785,Stream Fish Occupancy - Banff,944
+pc,07c1c8d0-ad43-4411-bb79-278f9f50fb96,Stream Fish Occupancy - Banff,32018465-b944-4d5c-9b48-e9345dbbd926,Stream Fish Occupancy - Banff - Data Dictionary,462
+esdc-edsc,07deee9b-4275-40ab-a0d3-9cd913feed47,"Workforce Representation by Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",38b2c87d-fe77-4400-8716-aea3643c54f2,"Workforce Representation by 4 Designated Groups by Canada, Provinces, Territories and Census Metropolitan Areas",5288
+esdc-edsc,07deee9b-4275-40ab-a0d3-9cd913feed47,"Workforce Representation by Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",98a5777b-acc3-42a1-8a56-02394d151065,"Workforce Representation by 4 Designated Groups by Canada, Provinces, Territories and Census Metropolitan Areas",5919
+esdc-edsc,07deee9b-4275-40ab-a0d3-9cd913feed47,"Workforce Representation by Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",2c3ea3ce-2fa5-4ec3-b29e-a663c63763fa,"Workforce Representation by 3 Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",4409547
+esdc-edsc,07deee9b-4275-40ab-a0d3-9cd913feed47,"Workforce Representation by Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",c4edddd9-074c-4383-acb4-3818e730a37a,"Workforce Representation by 3 Designated Groups, Employment Equity Occupational Groups and National Occupational Classification Unit Groups",5363113
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,f5b584ce-2086-4ad7-9161-871a4e29870a,"01. Number of Students who Received Student Financial Assistance in Canada, including Grants, Loans and Interest Subsidy, by Type of Assistance (number of recipients)",2107
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,0535a873-616e-4ef7-8ad6-2662bb612eb1,02. Number of Students who Received Grants in Canada by Type (number of recipients) ,1186
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,066e8f5e-1f21-45bf-997b-1b3012cbdb30,02. Number of Students who Received Grants in Canada by Type (number of recipients) ,1399
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,ecb39c4c-05ec-4f5c-9a29-a76b5d47e9d9,03. Value of Grants in Canada by Type (millions of dollars),1093
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,2d4c5bba-3365-4855-97b1-65f22463700a,03. Value of Grants in Canada by Type (millions of dollars),1302
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,9d90fcd1-cb1e-4d0a-9a59-294041a59ba2,"04. Number of Students who Received Canada Student Grants and/or Canada Student Loans in Canada by Gender, Age Group, Study Level and Institution Type (number of recipients)",1938
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,2bdb2408-8224-4b20-9da1-8c5c204cc813,"04. Number of Students who Received Canada Student Grants and/or Canada Student Loans in Canada by Gender, Age Group, Study Level and Institution Type (number of recipients)",2064
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,aa7f246b-9bc6-47a7-bbcf-ba0830796ca3,"05. Number of Students who Received Canada Student Grants in Canada by Gender, Age Group, Study Level and Institution Type (number of recipients)",1915
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,13e8d7c2-b303-41da-9c5e-7d78ddfe3843,"05. Number of Students who Received Canada Student Grants in Canada by Gender, Age Group, Study Level and Institution Type (number of recipients)",2041
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,c8d23160-2509-4acd-a2e1-6c54ed07912d,"06. Number of Students who Received Canada Student Loans in Canada by Gender, Age Group, Study Level and Institution Type (number of recipients)",1935
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,7b7c8989-6c8d-4125-8fad-e909f2634b7b,"06. Number of Students who Received Canada Student Loans in Canada by Gender, Age Group, Study Level and Institution Type (number of recipients)",2063
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,8112c664-3958-4e87-819f-f8018f2cc856,"07. Average Loan Balance at Time of Leaving School for Full-Time Students in Canada by Gender, Study Level and Institution Type (dollars)",1150
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,0c4e858f-2edf-4bb3-8e7b-654981f401d4,"07. Average Loan Balance at Time of Leaving School for Full-Time Students in Canada by Gender, Study Level and Institution Type (dollars)",1208
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,1f4d092a-88f4-4dfd-b047-457886edfaa0,08. Distribution of Loan Balance at Time of Leaving School for Full-Time Students in Canada by Debt Level (number of recipients),930
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,29a3b1bd-f8f0-4260-aefd-82314ff1317f,08. Distribution of Loan Balance at Time of Leaving School for Full-Time Students in Canada by Debt Level (number of recipients),921
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,4a73cec1-3f59-44df-a3b5-3832365c719e,09. Number of RAP Recipients in Canada by RAP Stage and Payment Type (number of recipients),1394
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,aeacc590-0a12-46f0-962d-8a976f782f9b,09. Number of RAP Recipients in Canada by RAP Stage and Payment Type (number of recipients),1442
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,fa008f14-2c45-4613-b645-b1c770f7579e,"10. Number of Students Benefiting from RAP in Canada by Gender, Age Group, Study Level and Institution Type (number of recipients)",1912
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,8290a7f7-0912-48e7-90ad-8926018828c6,"10. Number of Students Benefiting from RAP in Canada by Gender, Age Group, Study Level and Institution Type (number of recipients)",2042
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,880d2d90-4b10-4cac-bb44-5d60a3bbc7d3,11. Canada Student Loan Forgiveness for Family Doctors and Nurses in Canada by Profession and Fiscal Year (number of recipients),567
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,ab645281-8a65-4df5-bbbe-b74776217b64,11. Canada Student Loan Forgiveness for Family Doctors and Nurses in Canada by Profession and Fiscal Year (number of recipients),590
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,694af616-f6df-41f7-8e73-2085fb04ac64,12. Canada Student Loan Forgiveness for Family Doctors and Nurses in Canada by Profession and Fiscal Year (thousands of dollars),765
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,a5e2d86a-011b-4556-8143-a87ce4d9ab90,12. Canada Student Loan Forgiveness for Family Doctors and Nurses in Canada by Profession and Fiscal Year (thousands of dollars),788
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,65a05349-17cc-4b6f-90a6-2353be125480,13. Canada Student Loan Forgiveness for Family Doctors and Nurses in Canada by Place of Work and Fiscal Year (number of recipients),738
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,6251bd9c-99db-4690-a762-e9977992dfef,13. Canada Student Loan Forgiveness for Family Doctors and Nurses in Canada by Place of Work and Fiscal Year (number of recipients),758
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,0011fa66-05f8-47bf-b52b-27d38b6033b5,14. Canada Student Loan Forgiveness for Family Doctors and Nurses in Canada by Place of Work and Fiscal Year (thousands of dollars),1003
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,9c259288-7aff-4b00-89c6-c42768f38ea4,14. Canada Student Loan Forgiveness for Family Doctors and Nurses in Canada by Place of Work and Fiscal Year (thousands of dollars),1023
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,6d5b5430-b4ba-437f-8917-9f7efb09d1ce,15. Severe Permanent Disability Benefit in Canada,470
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,d9b064ec-5195-40c4-a87a-b5129196d985,15. Severe Permanent Disability Benefit in Canada,496
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,decf8349-c470-4291-8f75-faca24e86952,"16. Three-Year Default Rates for Direct Loans in Canada by Gender, Study Level and Institution Type (percent) ",1188
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,b3fa1893-0860-411f-8a4b-bf9ffc3fed3e,"16. Three-Year Default Rates for Direct Loans in Canada by Gender, Study Level and Institution Type (percent) ",1440
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,e7d181c3-fdb5-4786-a9f0-2b73dff89631,17. Overall Portfolio in Canada by Loan Regime at the end of Fiscal Year (millions of dollars),1267
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,a3e3f4e5-4290-447a-a6e4-14460ad0d586,18. Direct Loan Portfolio in Canada by Loan Status at the end of Academic Year (number of borrowers),925
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,1047b941-09f7-46be-9f88-d20375851439,18. Direct Loan Portfolio in Canada by Loan Status at the end of Academic Year (number of borrowers),1012
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,41398f02-c287-4d36-8871-d29c5eac6a55,19. Value of the Direct Loan Portfolio in Canada by Loan Status at the end of Academic Year (millions of dollars),936
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,97b79b74-cc2f-46dd-9986-80fcc9414ac4,19. Value of the Direct Loan Portfolio in Canada by Loan Status at the end of Academic Year (millions of dollars),972
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,9cafb163-3c26-4325-bd70-e7608ae73878,"20. Number of Students who Received Student Financial Assistance, Including Grants, Loans and Interest Subsidy, by Province and Territory (number of recipients)",1144
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,a6ba857f-3157-4649-a3a2-34ad083867d6,"20. Number of Students who Received Student Financial Assistance, Including Grants, Loans and Interest Subsidy, by Province and Territory (number of recipients)",1158
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,ef329cfc-bc41-49f0-86dd-453d22d277d6,21. Number of Full- and Part-Time Students who Received Canada Student Grants and/or Canada Student Loans by Province and Territory (number of recipients),1140
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,355e39ac-b841-4781-bd03-d37f6dc186dd,21. Number of Full- and Part-Time Students who Received Canada Student Grants and/or Canada Student Loans by Province and Territory (number of recipients),1154
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,280862eb-14fe-45a4-9ec6-f9eb4e6575a0,22. Value of Canada Student Grants and/or Canada Student Loans for Full- and Part-Time Students by Province and Territory (millions of dollars),1118
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,3e96cc0a-eb72-4676-9983-cf0f75710ef7,22. Value of Canada Student Grants and/or Canada Student Loans for Full- and Part-Time Students by Province and Territory (millions of dollars),1132
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,50504432-2bea-44a5-a206-fbdc90ef8e1b,23. Number of Full-Time Students who Received Canada Student Grants and/or Canada Student Loans by Province and Territory (number of recipients),1140
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,c11039e0-0d12-4f7f-916d-fe0a7a64f20f,23. Number of Full-Time Students who Received Canada Student Grants and/or Canada Student Loans by Province and Territory (number of recipients),1154
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,f2249ef5-152d-407e-aa45-1bca9525e35d,24. Value of Canada Student Grants and/or Canada Student Loans for Full-Time Students by Province and Territory (millions of dollars),1118
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,9d6f950c-2f6d-40e9-860e-13927ae75e30,24. Value of Canada Student Grants and/or Canada Student Loans for Full-Time Students by Province and Territory (millions of dollars),1132
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,4c0f7e0a-057e-4df2-b266-e18218bd5950,25. Number of Part-Time Students who Received Canada Student Grants and/or Canada Student Loans by Province and Territory (number of recipients),895
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,d2a86b13-cfc6-4809-a4ce-2815cc7f920e,25. Number of Part-Time Students who Received Canada Student Grants and/or Canada Student Loans by Province and Territory (number of recipients),909
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,03cc5bd9-883d-4a82-a168-dfad049c4482,26. Value of Canada Student Grants and/or Canada Student Loans for Part-Time Students by Province and Territory (millions of dollars),870
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,7fe45c67-f214-4837-838f-11a8807427cc,26. Value of Canada Student Grants and/or Canada Student Loans for Part-Time Students by Province and Territory (millions of dollars),883
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,278042ea-4296-41e7-b777-b0ba4003e804,27. Number of Full- and Part-Time Students who Received Canada Student Grants by Province and Territory (number of recipients),1116
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,efaf2bf6-ca02-4a1a-b714-4c5b326129d7,27. Number of Full- and Part-Time Students who Received Canada Student Grants by Province and Territory (number of recipients),1130
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,fcb2e2cd-53b9-404c-a980-e5e284652039,28. Value of Canada Student Grants for Full- and Part-Time Students by Province and Territory (millions of dollars),1025
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,092e8637-0789-42d9-987c-54af94f50c53,28. Value of Canada Student Grants for Full- and Part-Time Students by Province and Territory (millions of dollars),1039
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,2b43aa22-7749-4e14-8953-c05a21b687b7,29. Number of Full-Time Students who Received Canada Student Grants by Province and Territory (number of recipients),1115
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,a161285b-bd10-4479-bdf3-140cbebe3173,29. Number of Full-Time Students who Received Canada Student Grants by Province and Territory (number of recipients),1129
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,b750fe94-e182-4f32-a740-5332e070fb65,30. Value of Canada Student Grants for Full-Time Students by Province and Territory (millions of dollars),1041
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,1756e2e6-097a-4bfb-a672-d184c2292bae,30. Value of Canada Student Grants for Full-Time Students by Province and Territory (millions of dollars),1055
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,eb3f7ffd-bccf-42f7-9e04-6f03ef38439a,31. Number of Part-Time Students who Received Canada Student Grants by Province and Territory (number of recipients),885
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,fcb3419e-63c9-4435-9b22-7b5b8b98269d,31. Number of Part-Time Students who Received Canada Student Grants by Province and Territory (number of recipients),899
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,60d6b80a-ef26-4d53-8c53-16328b06dad2,32. Value of Canada Student Grants for Part-Time Students by Province and Territory (millions of dollars),831
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,5f70374e-5c3e-4858-960b-6086bb752515,32. Value of Canada Student Grants for Part-Time Students by Province and Territory (millions of dollars),845
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,08990820-40ad-4bf9-9161-1fe252f063ac,33. Number of Full- and Part-Time Students who Received Canada Student Loans by Province and Territory (number of recipients),1137
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,aab48f9c-801d-4c84-af60-f78da1c1ac70,33. Number of Full- and Part-Time Students who Received Canada Student Loans by Province and Territory (number of recipients),1151
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,15d4a230-a1cb-4eba-be8f-d44b55b57319,34. Value of Canada Student Loans for Full- and Part-Time Students by Province and Territory (millions of dollars),1086
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,deefd02d-da00-4d32-befe-583340bda1a1,34. Value of Canada Student Loans for Full- and Part-Time Students by Province and Territory (millions of dollars),1100
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,01119163-7186-4eb3-9b3c-0369de4401e2,35. Number of Full-Time Students who Received Canada Student Loans by Province and Territory (number of recipients),1134
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,7c879b7a-db5e-45fa-999e-506b76f2617d,35. Number of Full-Time Students who Received Canada Student Loans by Province and Territory (number of recipients),1148
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,cb10ff24-69d5-44e3-a060-2a20bdc897bd,36. Value of Canada Student Loans for Full-Time Students by Province and Territory (millions of dollars),1104
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,f67023fb-323d-43f7-a646-06b9e6d3c5b8,36. Value of Canada Student Loans for Full-Time Students by Province and Territory (millions of dollars),1118
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,afca47c6-543c-44e0-a040-fa11aa12d7c3,38. Value of Canada Student Loans for Part-Time Students by Province and Territory (millions of dollars),866
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,0d6a23af-4329-4662-9be0-74a6aee1cef6,39. Number of Students Receiving the Canada Student Grant for Full-Time Students by Province and Territory (number of recipients),1110
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,9b3182e2-ed23-446c-8b3b-a2db7b750e97,39. Number of Students Receiving the Canada Student Grant for Full-Time Students by Province and Territory (number of recipients),1124
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,d45c5471-2ee6-4626-8ad5-91f90bcc39fd,40. Value of the Canada Student Grant for Full-Time Students by Province and Territory (millions of dollars),1031
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,d4113ce0-1259-4a04-ac7d-b24d4495e041,40. Value of the Canada Student Grant for Full-Time Students by Province and Territory (millions of dollars),1045
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,948018f1-2d6e-4b29-9da2-7bcff6d8c4d9,41. Number of Students Receiving the Canada Student Grant for Full-Time Students with Dependants by Province and Territory (number of recipients),983
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,df52d467-014c-4d19-bfe9-83a9208d529a,41. Number of Students Receiving the Canada Student Grant for Full-Time Students with Dependants by Province and Territory (number of recipients),997
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,ce4c7547-3750-4a78-9a10-78b4ad6a6a3d,42. Value of the Canada Student Grant for Full-Time Students with Dependants by Province and Territory (millions of dollars),952
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,dbde77f4-e880-4abd-937a-f07650a6f966,43. Number of Students Receiving the Canada Student Grant for Students with Permanent Disabilities by Province and Territory (number of recipients),949
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,cab6851f-0378-41d6-bc92-6c973a6816f3,43. Number of Students Receiving the Canada Student Grant for Students with Permanent Disabilities by Province and Territory (number of recipients),963
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,615bfd12-14e0-42ce-8666-e605965d3b18,44. Value of the Canada Student Grant for Students with Permanent Disabilities by Province and Territory (millions of dollars),902
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,9ec08893-621e-4867-a438-d16004e7bfdc,45. Number of Canada Apprentice Loan Recipients by Province and Territories (number of recipients),689
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,c58b4a2e-f072-43a1-9257-7592ba1eeb1a,45. Number of Canada Apprentice Loan Recipients by Province and Territories (number of recipients),706
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,eece5099-dc5d-47af-adc9-8b4d2634295a,46. Value of Canada Apprentice Loans by Province and Territories (millions of dollars),699
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,9d176e7a-1e92-4744-843f-b24ab65d2763,46. Value of Canada Apprentice Loans by Province and Territories (millions of dollars),708
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,3c05e4bb-fb98-4123-af11-f106d85db979,47. Number of Full-Time Students Leaving School and Entering Repayment by Province and Territory (number of students),1082
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,5b6c52c3-ea20-4ee1-847c-0194d8a4df4c,47. Number of Full-Time Students Leaving School and Entering Repayment by Province and Territory (number of students),1096
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,e400c9f1-80fb-4cd2-bdd2-1296a2d8ad1b,48. Average Loan Balance at Time of Leaving School for Full-Time Students by Province and Territory (dollars),1157
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,8e959e1c-edbf-475a-a248-cf9bc795e47b,48. Average Loan Balance at Time of Leaving School for Full-Time Students by Province and Territory (dollars),1171
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,b9ccc5b3-5151-4f66-967d-d01597768958,"49. Number of RAP Recipients by RAP Stage, Payment Type and Province and Territory (number of recipients)",12738
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,b2927dc4-2c41-439b-8bb0-f9031a69c4cf,"49. Number of RAP Recipients by RAP Stage, Payment Type and Province and Territory (number of recipients)",13907
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,1c6d1fc4-5670-4f27-aeb2-40b9b37694d4,50. First Year RAP Uptake by Repayment Cohort and Province and Territory (number of borrowers),2980
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,77daf304-ac82-4de6-875a-8a0c9608a2b1,51. Three-Year Default Rates for Direct Loans by Province and Territory (percent),691
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,33bdd887-a9db-4efc-a9ea-f95a8749b36a,51. Three-Year Default Rates for Direct Loans by Province and Territory (percent),705
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,4a5bfb8d-83f3-4dbf-a79c-b37c4d19ee8f,52. Number of Full-Time Students Studying in their Home Province or Territory by Province and Territory (number of recipients),1105
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,bcb4bfdc-4d5f-4ea2-8057-355f9706f862,52. Number of Full-Time Students Studying in their Home Province or Territory by Province and Territory (number of recipients),1119
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,3c0dea5d-f21e-4938-b512-a2695e1e3de5,53. Number of Full-Time Students Studying in Canada but Away from their Home Province or Territory by Province and Territory (number of recipients),1015
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,3ae25d47-6d27-4487-88b2-526588e1ef71,53. Number of Full-Time Students Studying in Canada but Away from their Home Province or Territory by Province and Territory (number of recipients),1029
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,f11395dd-ab95-4c29-a824-0d4a608b21c1,54. Number of Full-Time Students Studying Outside of Canada by Province and Territory (number of recipients),889
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,b4bead00-9e49-4df4-9ee7-a88d6aad885a,54. Number of Full-Time Students Studying Outside of Canada by Province and Territory (number of recipients),903
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,8b5e8e3d-e606-4841-afa6-14c9ff0b6fc7,55. Historical Data: Number of Full-Time Students who Received Canada Student Loans by Academic Year and Province and Territories (number of recipients),4614
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,0fccc768-4c75-4794-bb9e-82b8b87da127,55. Historical Data: Number of Full-Time Students who Received Canada Student Loans by Academic Year and Province and Territories (number of recipients),4610
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,0c9e8714-adb2-4fac-a787-fee5b0ba89ef,56. Historical Data: Value of Canada Student Loans for Full-Time Students by Academic Year and Province and Territories (millions of dollars),4042
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,f303dfa4-52bc-42e8-b551-911d00d3b38c,56. Historical Data: Value of Canada Student Loans for Full-Time Students by Academic Year and Province and Territories (millions of dollars),4140
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,e6d1e9d1-d21d-4f39-85e4-04564ef3604c,57. Historical Data: Number of Part-Time Students who Received Canada Student Loans and their Value by Academic Year,763
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,132b5b26-77dd-4ae4-8b85-5c5f79871490,57. Historical Data: Number of Part-Time Students who Received Canada Student Loans and their Value by Academic Year,779
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,0a5f0197-5272-433d-92e2-42bb7a8c8696,"58. Historical Data: Number of Students who Received Canada Student Grants by Grant Type, Academic Year and Province and Territory (number of recipients)",2819
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,7d1197c7-0507-4785-9a68-a471712dedf8,"58. Historical Data: Number of Students who Received Canada Student Grants by Grant Type, Academic Year and Province and Territory (number of recipients)",3382
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,bdd19ab0-5641-4878-8c6a-ac7b8450c41e,"59. Historical Data: Value of Canada Student Grants by Grant Type, Academic Year and Province and Territory (millions of dollars)",2591
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,7866f09e-b5cf-48a9-90de-cd03556d2161,"59. Historical Data: Value of Canada Student Grants by Grant Type, Academic Year and Province and Territory (millions of dollars)",3154
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,0bef067b-3ae8-46a7-9776-085c15b2e895,60. Historical Data: Number of Part-Time Students who Received Canada Student Grants by Academic Year and Province and Territory (number of recipients),1537
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,fc6019f0-8330-4215-832d-f362ee43e5e5,60. Historical Data: Number of Part-Time Students who Received Canada Student Grants by Academic Year and Province and Territory (number of recipients),1682
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,91578cd0-6164-4a7c-9fd3-5571253f5447,61. Historical Data: Value of Canada Student Grants for Part-Time Students by Academic Year and Province and Territory (millions of dollars),1451
+esdc-edsc,0840231b-5bbf-447f-81ce-3ec0673aefc4,Student Financial Assistance Data for the Canada Student Financial Assistance Program,f084d9d8-fecb-4b8a-b57c-e9d7daa83b7c,61. Historical Data: Value of Canada Student Grants for Part-Time Students by Academic Year and Province and Territory (millions of dollars),1596
+pc,0938086c-fc6f-49c5-be1b-458e67cb6450,Lake Water Quality - Cape Breton Highlands,91cd820d-bdb2-40af-987f-80c861e4c63b,Lake Water Quality - Cape Breton Highlands - Data Summary - 1,6064
+pc,0938086c-fc6f-49c5-be1b-458e67cb6450,Lake Water Quality - Cape Breton Highlands,05658c42-6cc0-4723-b535-d3fdffd448eb,Lake Water Quality - Cape Breton Highlands - Data Dictionary - 2,381
+pc,093bcc9c-04d6-4ba0-a96c-c1eb6db8356c,Grassland Birds - Waterton Lakes - Grasslands,8a7b806b-5339-46e3-8a3d-e81abb210632,Grassland Birds - Waterton Lakes - Bird Diversity and Abundance data - 1,898080
+pc,093bcc9c-04d6-4ba0-a96c-c1eb6db8356c,Grassland Birds - Waterton Lakes - Grasslands,c6d97b11-1a86-45a6-8b04-b3818b2657c9,Grassland Birds - Waterton Lakes - Bird Diversity and Abundance data dictionary - 2,8092
+cnsc-ccsn,0968ddc5-710e-4388-b379-184764df6f4c,Darlington New Nuclear Project - Information and Reports,67179649-94c4-4c66-a593-e8564574f4d3,Registry of Substantive Documents for the Darlington New Nuclear Project,59554
+pc,0a827e84-278c-4150-aeef-77eb9c9612ce,Active Layer - Ukkusiksalik,dc7e21b5-017e-488f-834a-ed622bb4ec03,Active Layer - Ukkusiksalik - Circumpolar Active Layer Monitoring Grid Data - 1,25342
+pc,0a827e84-278c-4150-aeef-77eb9c9612ce,Active Layer - Ukkusiksalik,e7411142-69b1-45e2-ac59-0339f7670003,Active Layer -Ukkusiksalik - Circumpolar Active Layer Monitoring Grid Data Dictionary - 2,372
+pc,0ac3c0c3-62d6-4308-bd8a-96a088e363b2,Seedling Survival  - Waterton Lakes - Conservation and Restoration Project (Five needle pine),af3049ff-f341-4bc4-8e21-9edb78f7bc47,Seedling Survival - Waterton Lakes - Health data - 1,3704158
+pc,0ac3c0c3-62d6-4308-bd8a-96a088e363b2,Seedling Survival  - Waterton Lakes - Conservation and Restoration Project (Five needle pine),f03cd8d1-e70d-442e-ab5b-f2d7c5ba0b9f,Seedling Survival - Waterton Lakes - Health data dictionary - 2,1953
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,1d621f82-4587-4af0-adb3-53a5e4459fe0,CPPD Initial applications received by age group,690
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,5d34cab7-fdb8-4290-960d-e03f80db515c,CPPD Initial applications received by age group,694
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,2123642d-7733-4c8a-9271-4ba5711f14c7,CPPD Initial applications received by gender,252
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,46482ed1-512e-4c34-a637-b9ac422d2c47,CPPD Initial applications received by gender,268
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,5d2c7268-1af9-46db-bdbe-371c2edd1f52,CPPD Initial applications received by province,988
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,c2c914b6-5d98-4b6c-8538-6be172943c6f,CPPD Initial applications received by province,998
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,8d3515f2-33fd-45cc-ade8-d7fd6e3d2956,CPPD Initial applications granted by age group,632
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,445e5bcf-b5dc-4bfb-b9d5-3e71a7b3738d,CPPD Initial applications granted by age group,636
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,abd367e3-ee3b-4c45-8397-6b3744ca85f2,CPPD Initial applications granted by gender,252
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,8aefab54-0e33-44c3-bccf-1f3cfcf0bb80,CPPD Initial applications granted by gender,268
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,6d8edb4a-ada9-42a4-ac6f-a5f52682594b,CPPD Initial applications granted by province,816
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,2cecc719-6a4e-4f15-8a07-e9e455dce004,CPPD Initial applications granted by province,815
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,789d4e4c-69ec-471c-aee1-d5a695d4b1e0,CPPD Initial applications denied by age group,654
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,ce5cb8f6-ecd7-4c29-96a5-2bffaa35a761,CPPD Initial applications denied by age group,658
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,2656c72c-37d9-47d2-86d5-59fce3bd0a78,CPPD Initial applications denied by gender,252
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,4d627b1c-a8d5-40b3-9d0d-2aaa3b78d0e2,CPPD Initial applications denied by gender,268
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,1f932576-a036-4335-a6f2-9916783063fa,CPPD Initial applications denied by province,941
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,54636602-f6df-4c9d-a141-a4d3efdc336d,CPPD Initial applications denied by province,951
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,d415d79d-a83a-4077-88cb-529de0a7f0f7,CPPD Automatic reinstatements received by gender,200
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,63649dd4-0ccc-49f3-85c7-462aa6a52a9f,CPPD Automatic reinstatements received by gender,216
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,cd054267-f4f3-46cf-963b-022cac97c084,CPPD Automatic reinstatements granted by gender,200
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,1f7333e3-5d9e-4f07-b2bc-0e3a63ec6b14,CPPD Automatic reinstatements granted by gender,216
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,a14f6892-1595-4fdd-a465-bc1b0ff3614e,CPPD Automatic reinstatements denied by gender,215
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,6e59befe-6e9f-48bd-8917-a628941e0fd9,CPPD Automatic reinstatements denied by gender,234
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,5a1526ce-91ed-48aa-8bf7-7f3fa163d464,CPPD Fast Track reapplications received by gender,178
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,23409427-f6e0-48c0-b08d-6737e578acfb,CPPD Fast Track reapplications received by gender,194
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,007210f7-e0f4-4e08-aaaa-d7f472d84163,CPPD Fast Track reapplications granted by gender,175
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,2a1581f4-76fb-4aa3-9029-56a564e063f8,CPPD Fast Track reapplications granted by gender,191
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,7a8e65d8-cba3-4e5f-ab97-dfe28a7ddb29,CPPD Fast Track reapplications denied,136
+esdc-edsc,0afa67e7-2aae-4827-a038-d988e90db7af,Canada Pension Plan Disability (CPPD) Benefit Applications,9623ebea-acd1-4500-9064-5bac2e76bf0b,CPPD Fast Track reapplications denied,133
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,c0df89da-0467-4a9c-9c34-64d1c1f1950c,Financial data,
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,b718eb3f-6cea-460b-b0e4-fd4e3ab3de6d,General information ,
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,44edac4b-2529-482f-8c71-310cb6152e6b,Non-Qualified donees,
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,f9a58149-8224-4717-a77d-f599b33d6d78,Private/Public Foundations,
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,e4a680fe-5ae5-408d-b199-28c422ac4df0,Activities outside Canada – Countries where program was carried,
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,e1b30ae1-34d2-4052-8157-3cd8d79d74bb,Activities outside Canada – Details on financial,
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,caaaafb3-e004-462b-86b2-8416ee5b5c24,Activities outside Canada - Exported goods,
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,aa057433-cac3-4e7d-a179-5e638725b580,Compensation,
+cra-arc,0bb1fb56-74d0-47f4-b4b3-2b574229416d,2014 List of charities,cedded83-a08d-4be5-bb6a-1736cdbf429c,Political Activities – Funding,
+wd-deo,0bf21cf5-adda-4b1a-a337-2a79ab57d465,Number of high growth firms in western Canada,070fc238-a8a7-4889-8629-74821697485a,High Growth Firms_e.csv,131
+pc,0c373e35-b373-41d9-ba07-053c7b6fe073,Moose Density - Fundy,52b09d98-5380-4cfe-aa75-a63847adf0fb,Moose Density - Fundy - 1,5423
+pc,0c373e35-b373-41d9-ba07-053c7b6fe073,Moose Density - Fundy,af36169d-5e52-4d99-b1fc-36678acf4032,Moose Density - Fundy - Data Dictionary,605
+pc,0db57c16-b1b4-479d-a3e2-a1bb9df844f7,Delta water extent (remote sensing) - Wood Buffalo National Park,0fa0137e-a8ed-4791-bf3b-98d584e6ef33,Delta water extent (remote sensing),1730
+pc,0db57c16-b1b4-479d-a3e2-a1bb9df844f7,Delta water extent (remote sensing) - Wood Buffalo National Park,3feaf662-7f16-47ee-bffa-b05e307711e2,Delta water extent (remote sensing) - Data Dictionary,273
+lac-bac,0ddba181-11e2-4282-a718-99f3f5e8d9c5,Published documents acquired during the year that are processed,c29668f0-0f43-4054-b80c-2fbd86665926,Published documents acquired during the year that are processed,538
+pc,0e3b7735-2138-4a27-93bc-6910117517a8,Bison Abundance (CoRe),e9bef25d-6fff-4214-b31e-234b30317f90,Bison Abundance (CoRe),293
+pc,0e8130e9-2de9-450d-8a24-5a12b4a51286,Alpine Birds  - Jasper,056e3387-bdcd-459d-865a-3a0d0dc19cce,Alpine Birds  - Jasper,238454
+pc,0e8130e9-2de9-450d-8a24-5a12b4a51286,Alpine Birds  - Jasper,c60f1dc3-0c9d-4a75-a85c-f05abf47c8db,Alpine Birds  - Jasper - Data Dictionary,7640
+tbs-sct,0eaf7a0b-e6a1-40e7-b8f9-99ca1cde27ad,Data Strategy Tracker,dedc62b0-bf98-45ec-a8bc-2c1633f8d61e,Data Strategy Tracker,62075
+cfia-acia,0ebac9e8-632f-497e-b31e-b7da66c31cb6,"Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens in Fermented Tea (Kombucha) - April 1, 2018 to March 31, 2019",91e72e65-6e74-4493-9bae-a83a282a8127,"Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens in Fermented Tea (Kombucha) - April 1, 2018 to March 31, 2019",101910
+pc,0ed5aa1b-19b9-443a-b727-40abbe3b47aa,Kootenay_NP_ForestAlpine_Songbird Point Counts ,7db20f25-1415-4852-96b7-81968f178ac6,Alpine and Forest Bird Species Relative Abundance - Kootenay,998739
+pc,0ed5aa1b-19b9-443a-b727-40abbe3b47aa,Kootenay_NP_ForestAlpine_Songbird Point Counts ,5fe58cde-5e5a-4d64-a170-c26b0aa0edf4,Alpine and Forest Bird Species Relative Abundance - Kootenay - data dictionary,15264
+cfia-acia,0f0e5884-9c1e-4171-bd33-42bcee1f2a01,CFIA List of Peer-reviewed Scientific Publications 2012-2023,2957b7e0-aee0-4c4c-836c-b992ba700675,"CFIA List of Peer-Reviewed Scientific Publications, 2023",368664
+pc,0f520d69-1462-4dcb-8947-4a72c0e9577b,Wetland Nutrient Status - Pitcher Plant Morphology - Terra Nova,2b5dddaa-0ffd-4b86-8818-99f998e79ee4,Wetland Nutrient Status - Pitcher Plant Morphology - Terra Nova,245754
+cfia-acia,0f679b1a-97a5-4460-bc3b-6c46fc16a978,Insect and plant species occurrence data to validate standardized Mahalanobis distance model,f987d6f2-97e1-4f00-8fad-a9a4229e4038,Insect and plant species occurrence data to validate standardized Mahalanobis distance model,
+cfia-acia,0f679b1a-97a5-4460-bc3b-6c46fc16a978,Insect and plant species occurrence data to validate standardized Mahalanobis distance model,2a77852e-4e78-4f76-913f-936e0d1761c9,Insect and plant species occurrence data to validate standardized Mahalanobis distance model,
+pc,1008ac61-7454-4f08-8f29-e6457c59393b,Trends in coastal dynamics - Forillon,8a247dc1-aa78-47bc-b30a-5c6d7f4b4b40,Trends_in_coastal_dynamics - Forillon,25717
+pc,1008ac61-7454-4f08-8f29-e6457c59393b,Trends in coastal dynamics - Forillon,8d6cbd77-a419-43f2-ba27-ff06148a4b9c,Trends_in_coastal_dynamics - Forillon,10360
+pc,104917c7-7f78-4a53-bbc8-ba866b7aea84,LESSS Areal Extent - Point Pelee,f2fd3c07-e1ba-47b5-b284-62694ef0a825,LESSS Areal Extent - Point Pelee - Monitoring Data,1073
+pc,104917c7-7f78-4a53-bbc8-ba866b7aea84,LESSS Areal Extent - Point Pelee,cba6db97-8d8c-49ba-8cc2-4259251bb05e,LESSS Areal Extent - Point Pelee - Monitoring Data Dictionary,1437
+pc,10d688ba-0fe4-4cdf-8830-4387e6c174c3,Area Burned - Yoho,113df590-f038-4b25-8716-3659f364db39,Area Burned - Yoho,6689
+pc,1115ef08-6a64-4c7e-90ef-010f01925339,Stream Benthic Invertebrates - Prince Edward Island,7b681850-4292-45d5-b44a-9faed297baf7,Stream Benthic Invertebrates - Prince Edward Island,879
+pc,117faba5-a9f2-4e2e-9864-3defe4f48a40,Tern Abundance - Terra Nova,7587afa6-63c1-489a-8db2-a4e5154741b0,Tern Abundance - Terra Nova,31678
+pc,117faba5-a9f2-4e2e-9864-3defe4f48a40,Tern Abundance - Terra Nova,0a014a00-4808-4a84-a8e3-1c34a91de7cc,Tern Abundance - Terra Nova - Data Dictionary,913
+dnd-mdn,1270405b-fa35-49a5-800e-a8ddac54a086,Canadian Armed Forces Vehicle Equipment List,1193c333-f197-4854-9baa-badef3d8765a,Canadian Armed Forces Vehicle Equipment List,128691
+pc,12cafe67-8fdb-46d4-b07f-cb8ae5e6edc9,Prescribed Fire Targets - Mount-Revelstoke,0aeb2b0a-225b-4ff8-9434-bb9c4874b174,Prescribed Fire Targets - Mount-Revelstoke,828
+pc,12cafe67-8fdb-46d4-b07f-cb8ae5e6edc9,Prescribed Fire Targets - Mount-Revelstoke,279fa505-da46-4d79-8b07-2428e2edf324,Prescribed Fire Targets - Mount-Revelstoke - Data Dictionary,828
+pc,12e17685-405d-4f7e-8c46-404323daf70d,Coastal Erosion - Prince Edward Island,922a4f59-0e48-4fca-a8a1-fc326aef0f62,Coastal Erosion - Prince Edward Island - Ground Survey Data - 1,66807
+pc,12e17685-405d-4f7e-8c46-404323daf70d,Coastal Erosion - Prince Edward Island,bb427057-8e4a-48f8-937c-fca6bfe5ead1,Coastal Erosion - Prince Edward Island - Remote Sensing Data - 2,306975
+pc,12e17685-405d-4f7e-8c46-404323daf70d,Coastal Erosion - Prince Edward Island,ded19511-30b3-47fd-8d55-d4ae7baf1ed7,Coastal Erosion - Prince Edward Island - Data Dictionary - 3,699
+pc,14020ea8-07bd-4cec-aab2-4b63cffc3be4,Pond Productivity - Prince Edward Island,90d81450-4055-44ec-9ddc-a6b3e567048c,Freshwater Productivity - Prince Edward Island,3897139
+cra-arc,1410eb45-59c4-4735-9121-ed314ccd767f,Departmental Results Framework indicators 2020-2021 Edition – Indicator 1: Percentage of tax returns filed on time,42916aae-ca98-4d67-98e0-6483086e7002,Departmental Results Framework Indicator 1: Percentage of tax returns filed on time,242
+cra-arc,1410eb45-59c4-4735-9121-ed314ccd767f,Departmental Results Framework indicators 2020-2021 Edition – Indicator 1: Percentage of tax returns filed on time,08b9ae3d-3732-457d-b0e8-67a3a2e206ee,Departmental Results Framework Indicator 1: Percentage of tax returns filed on time,327
+cfia-acia,1479f47f-cfbd-4d94-92e7-ea9b530627d7,CFIA Undeclared Peanuts in Hummus - 2014-2015,b1c97792-57d7-4a99-afba-c3afb22fba23,CFIA Undeclared Peanuts in Hummus - 2014-2015 ,44770
+pc,150beb08-b9bd-4441-a36e-fc624cf31c95,Breeding Bird Communities- Ivvavik,a3f683db-b5be-41c3-8c6b-1a1bf5279765,Breeding Bird -  Ivvavik - 2009-2014 - data - 1,22635
+pc,150beb08-b9bd-4441-a36e-fc624cf31c95,Breeding Bird Communities- Ivvavik,58424fe2-6c84-4a0e-a60c-b44d343439d9,Breeding Birds - Ivvavik - 2015-2017 Margaret Lake - data - 2,3785
+pc,150beb08-b9bd-4441-a36e-fc624cf31c95,Breeding Bird Communities- Ivvavik,af80da3e-807d-4997-b51a-3292bf01da52,Breeding Bird -  Ivvavik - 2015-2017 - Sheeps Creek - data - 3,3748
+pc,150beb08-b9bd-4441-a36e-fc624cf31c95,Breeding Bird Communities- Ivvavik,13263325-1b44-48a7-a00a-2157ee619f13,Breeding Birds - Ivvavik - 2009-2017-data dictionary,2459
+esdc-edsc,15e31370-ac4a-45a6-926b-02dd372bfd7a,"Monthly average number of Canada Pension Plan (CPP) disability benefits by province, gender, and calendar year",a9d69505-947f-4f55-b6d1-e2bf3d7e197d,"Monthly average number of Canada Pension Plan (CPP) disability benefits by province, gender, and calendar year",2341
+esdc-edsc,15e31370-ac4a-45a6-926b-02dd372bfd7a,"Monthly average number of Canada Pension Plan (CPP) disability benefits by province, gender, and calendar year",201ff621-52f5-43ec-b164-304658143495,"Monthly average number of Canada Pension Plan (CPP) disability benefits by province, gender, and calendar year",2569
+pc,1658d302-39e7-465b-a0ae-1ef80994d817,Exotic Invasive Plants - Kouchibouguac,4c482cee-4aab-4b93-9a2a-adb801892ef5,Exotic Invasive Plants - Kouchibouguac - Data,229921
+pc,1658d302-39e7-465b-a0ae-1ef80994d817,Exotic Invasive Plants - Kouchibouguac,effd2675-fa73-4ca8-bf09-97ebb5d25fdb,Exotic Invasive Plants - Kouchibouguac - Metadata,5618
+pc,1658d302-39e7-465b-a0ae-1ef80994d817,Exotic Invasive Plants - Kouchibouguac,de72b1d5-acb8-47ec-b83b-1e0cd8e25bc7,Exotic Invasive Plants - Kouchibouguac - Data Dictionnary,15946
+pc,173006c2-d77c-43c6-a40d-b79387bafba7,Moose - Pukaskwa ,8aede14b-f766-4aa4-b551-9c478d5ffd69,Moose - Pukaskwa - Survey Data - 1 ,29303
+pc,173006c2-d77c-43c6-a40d-b79387bafba7,Moose - Pukaskwa ,32cda235-cb3c-49ba-ace7-1670ab2821e9,Moose - Pukaskwa - Plot Information - 2,2299
+pc,173006c2-d77c-43c6-a40d-b79387bafba7,Moose - Pukaskwa ,fb1231f1-44c6-4dde-8c0e-cc7da439c5a1,Moose - Pukaskwa - Data Dictionary,2132
+pc,1767776a-38dc-44b4-a1d7-d919796b0fb0,Salamanders - Kouchibouguac,dae8e8b0-6f39-4412-a8fb-f1c007ad6a5f,Salamanders - Kouchibouguac - Metadata,4696
+pc,1767776a-38dc-44b4-a1d7-d919796b0fb0,Salamanders - Kouchibouguac,53f61992-c32b-4436-a366-28439a2d5226,Salamanders - Kouchibouguac - Data Dictionnary,3656
+pc,177f4099-8624-4c5b-98f5-dd0e96abf233,Wetland Habitat Succession Interspersion - Point Pelee,9456a080-2069-455d-8e01-caa24f3e5cf2,Wetland Habitat Succession Interspersion - Point Pelee - Monitoring Data,763
+cic,17f69360-123a-4bd2-8eef-bba94468071f,"Immigration, Refugees and Citizenship Canada Glossaries ",bfd6c1fb-42d9-4c2d-ae5e-4a628db7e486,IRCC - Citizenship Program Glossary,64370
+dnd-mdn,18beb583-8dbe-434e-ba49-970658fcd6ef,Canadian Armed Forces Equipment,3caaab28-e441-4934-89ae-f1644cc7990d,Canadian Armed Forces Equipment,16967
+dnd-mdn,18beb583-8dbe-434e-ba49-970658fcd6ef,Canadian Armed Forces Equipment,14dda31b-680b-4f04-b2d2-eca7f7c73fd7,Équipement des Forces armées canadiennes,18329
+dnd-mdn,18beb583-8dbe-434e-ba49-970658fcd6ef,Canadian Armed Forces Equipment,7f5ae59b-908a-4866-96c6-7c9f57af4a91,Canadian Armed Forces Equipment,16971
+pc,19090a4c-7b56-4923-9363-4da6919c5cfe,Arctic hare population size - Gros Morne,1176a57c-cd15-414e-bcc1-417a4e11225d,Arctic hare population size - Gros Morne - Data,23706
+pc,19090a4c-7b56-4923-9363-4da6919c5cfe,Arctic hare population size - Gros Morne,a12304fd-aec7-450e-bbce-4c04c320e9ec,Arctic hare population size - Gros Morne - Data dictionary ,1124
+pc,192ccf66-987a-4f95-9c69-910383d9875b,Fish Community - Prince Edward Island,518a381a-a1fc-4305-aad2-2408721f283b,Fish Community - Prince Edward Island - Biodiversity Data - 1,375095
+pc,192ccf66-987a-4f95-9c69-910383d9875b,Fish Community - Prince Edward Island,587cf2d6-84f0-46e1-ab4f-f71aa6cd61e1,Fish Community - Prince Edward Island - American Eel Length Data 2,270766
+pc,192ccf66-987a-4f95-9c69-910383d9875b,Fish Community - Prince Edward Island,1af3006b-ee2a-4075-a122-6fc27e9ef3a9,Fish Community - Prince Edward Island - Data Dictionary,594
+pc,1947229a-be15-4b10-bfdb-b2f0fc5f39e6,Bison abundance - Wood Buffalo National Park,f693704f-9702-46af-95e8-c10112d582dd,Bison abundance - Wood Buffalo,435136
+pc,1947229a-be15-4b10-bfdb-b2f0fc5f39e6,Bison abundance - Wood Buffalo National Park,9ab7f53c-93c3-4965-888f-b477ec3f7532,Bison abundance - Wood Buffalo - Data Dictionary,4200
+tc,1991fef6-9dfe-40e2-a0c6-19c60ddf4a02,Vehicle Recalls- Last 60 Days,0230f847-b1cd-4528-8584-b4b02ba9d76a,Test Dataset,11754171
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,12d25fc0-462a-45aa-9ce6-b0017d5846ff,Table 1: Number of electors and polling stations,954
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,349b9d4d-b453-4bd2-affe-7fbb41a1b10e,Table 3: Number of ballots cast and voter turnout,1309
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,14b9f26e-8838-4da8-9f6b-c498fdfabe47,Table 5: Distribution of valid votes by voting method,1019
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,b2b05fdc-508b-400b-9461-08cb2da8c2bf,Table 6: Distribution of valid votes under Special Voting Rules,715
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,fe797752-9dc0-42a0-a286-413ee1d4e832,Table 7: Distribution of seats by political affiliation and sex,2696
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,f35f83d4-d333-43ed-89d9-ddead330f6f9,Table 8: Number of valid votes by political affiliation,2908
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,358a7505-0e99-425b-acba-81204a0f0dd8,"Table 10: Number of candidates by percentage of valid votes received, by political affiliation",1785
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,fce53469-baac-4e35-adcb-8cf9883aff0c,Table 11: Voting results by electoral district,47420
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,23253a8d-88d7-4710-8945-10ec896e5a11,Table 12: List of candidates by electoral district and individual results,376453
+elections,199e5070-2fd5-49d3-aa21-aece08964d18,43rd General Election: Official Voting Results,a0e55318-c04a-480d-9290-85f26ba2c5f7,Table 13: List of returning officers,40096
+pc,1a0a40c4-a5dc-4424-93ff-7234b30e1bea,Wetland Anthropogenic Footprint - Terra Nova,bcef286a-bd10-4350-91e1-bf2c97c23273,Wetland Anthropogenic Footprint - Terra Nova,4571
+pc,1adf3f2a-c940-45a4-a524-105267a52d25,Caribou - Nahanni ,b98d8d2a-e4cd-44ee-b0fc-b98237f3c175,Caribou - Nahanni - Data,41289
+pc,1adf3f2a-c940-45a4-a524-105267a52d25,Caribou - Nahanni ,402a5626-9e1f-4823-a2c9-c224be046d23,Caribou - Nahanni - Data dictionary,306
+cbsa-asfc,1b1c2b92-b388-47d9-87d4-01aee8d3c3e4,Traveller volumes by port of entry and month,22653cdd-d1e2-4c04-9d11-61b5cdd79b4e,Traveller Volumes by Port of Entry and month,29195108
+cbsa-asfc,1b1c2b92-b388-47d9-87d4-01aee8d3c3e4,Traveller volumes by port of entry and month,d5031871-3338-4cc7-8abb-c6ed7c7a447f,Traveller Volumes by Port of Entry and month,28410885
+dnd-mdn,1b2313e1-6d1b-4a04-aa11-1700661ebdea,Human resource staffing for Canadian Joint Operations Command,6e1d6e49-42c9-4003-ad80-b307b432addf,Human resource staffing for CJOC,1289
+pc,1b52d557-bc53-44bc-97dd-b4d6301d967a,Coastal Species at Risk - Prince Edward Island,32f4ba8c-eea3-454e-b139-a780e3790c33,Coastal Species at Risk - Prince Edward Island - Gulf of St. Lawrence Aster data - 1,2051
+pc,1b52d557-bc53-44bc-97dd-b4d6301d967a,Coastal Species at Risk - Prince Edward Island,75ce2486-ce12-4232-b93f-4e82dcb54012,Coastal Species at Risk - Prince Edward Island - Piping Plover Data - 2,98751
+pc,1b52d557-bc53-44bc-97dd-b4d6301d967a,Coastal Species at Risk - Prince Edward Island,d46ca9a7-75d9-4f89-be42-6aad769dd735,Coastal Species at Risk - Prince Edward Island - Beach Pinweed Data - 3,69158
+pc,1b52d557-bc53-44bc-97dd-b4d6301d967a,Coastal Species at Risk - Prince Edward Island,429e9cb5-814a-4921-a1df-af238e25099a,Coastal Species at Risk - Prince Edward Island - Data Dictionary,4317
+esdc-edsc,1be81c55-7bde-41bc-aa15-3cfa39bc0b0c,Canada Summer Jobs 2023: Organizations that received funding and the number of jobs they created,5fb374c3-08c2-48c3-b17e-bc09913d31c6,Alberta,191712
+pc,1bf98033-c7be-449e-a1da-12f4503249e8,Moose Abundance - Cape Breton Highlands,1c3c0694-2f6c-428a-9753-8a47cf7fb874,Moose Abundance - Cape Breton Highlands - Stratification Data - 1,360022
+pc,1bf98033-c7be-449e-a1da-12f4503249e8,Moose Abundance - Cape Breton Highlands,2fca96a9-d2ef-42ec-b9fa-de38983d748b,Moose Abundance - Cape Breton Highlands - Survey Unit Standard Data - 2,20443
+pc,1bf98033-c7be-449e-a1da-12f4503249e8,Moose Abundance - Cape Breton Highlands,d80fbfe4-ecd9-4231-9510-54ff3ecd9ba8,Moose Abundance - Cape Breton Highlands - Data Dictionary,2198
+pc,1c05f0a6-4049-4065-8d9c-9fde1af5d38e,Forest Bird Community - Nahanni,d4e76643-c2cb-4275-88b0-9ea9fdce112b,Forest Bird Community - Nahanni - Data,38203
+pc,1c05f0a6-4049-4065-8d9c-9fde1af5d38e,Forest Bird Community - Nahanni,7d661838-7b24-448f-ace9-8b6220a9b35d,Forest Bird Community - Nahanni - Data dictionary,8567
+pc,1c5afb33-911e-4023-af7b-84df423a43b0,Amphibian Occupancy - Mount Revelstoke,961d886d-f65f-450c-859b-a85f40eb7e85,Amphibian Occupancy - Mount Revelstoke,19923
+esdc-edsc,1d8098b3-0fb2-4006-a38a-ac2b9356065a,Yearly Registered Education Savings Plan (RESP) Withdrawals by Forward Sortation Area ,33cccd5b-70b8-4aca-b408-de6ef486b652,Yearly Registered Education Savings Plan (RESP) Withdrawal by Forward Sortation Area ,134276
+esdc-edsc,1d8098b3-0fb2-4006-a38a-ac2b9356065a,Yearly Registered Education Savings Plan (RESP) Withdrawals by Forward Sortation Area ,aac6046f-79af-473f-a5ed-be2fa408e1f1,Yearly Registered Education Savings Plan (RESP) Withdrawal by Forward Sortation Area ,134332
+pc,1dba647e-f99c-46fc-8ac0-968f781925bb,Tundra_Gull_Mingan_Number of nest_Data,0bfc36f4-affb-4ec0-beb6-fa0b8fadaa7e,Gull number of nest in the tundra- Mingan-Number of nest data,341272
+pc,1dba647e-f99c-46fc-8ac0-968f781925bb,Tundra_Gull_Mingan_Number of nest_Data,07092b50-9f10-48c0-a7f1-621f065b5f7e,Gull number of nest in the tundra- Mingan-Number of nest data_Data_dictionary,924
+dfatd-maecd,1dff365e-384d-423e-8e40-a3c2fb56f959,The GAC Files episodes,cddbbbb6-00a9-404b-96ee-9f04e0cdea24,The GAC Files episodes,86720
+tc,1eb9eba7-71d1-4b30-9fb1-30cbdab7e63a,National Collision Database,1a34f938-a742-4d14-b2ef-72cb1f4ece44,National Collision Database (99_TO_2001),59325940
+pc,1ebaab9a-0484-4f9f-89bb-29637c18f792,Forest Non-Native Vegetation - Kootenay,ee428ccc-2258-421d-8d70-04dbda436ea3,Forest Non-Native Vegetation - Kootenay,3798
+pc,1ebaab9a-0484-4f9f-89bb-29637c18f792,Forest Non-Native Vegetation - Kootenay,37b65a60-04d1-48ed-9646-366c860903c6,Forest Non-Native Vegetation - Kootenay - data dictionary,587
+nrcan-rncan,1effc7fc-301b-46d1-9fe0-e629f1106631,TOPIC Alberta - Traits of understory vegetation in Alberta - Specific Leaf Area,4383bc5a-e829-4271-9080-9fb261105a0d,Traits data,159652
+nrcan-rncan,1effc7fc-301b-46d1-9fe0-e629f1106631,TOPIC Alberta - Traits of understory vegetation in Alberta - Specific Leaf Area,e00312d6-3191-4cda-a58e-ee347ee8663a,Data dictionary,5170
+nrcan-rncan,1effc7fc-301b-46d1-9fe0-e629f1106631,TOPIC Alberta - Traits of understory vegetation in Alberta - Specific Leaf Area,e7cdad96-569f-4d9b-8de9-4356c741a038,Traits description,430
+pc,1f021f44-7a01-42f1-8100-39cbe9113331,Amphibian Occupancy - Glacier,6f540fbe-88b7-404a-b479-12b6ad4f0ab8,Amphibian Occupancy - Glacier,48774
+hc-sc,1f15ca45-8bfd-4f9c-9ec6-2c0c440e69c2,"Canadian Student Tobacco, Alcohol and Drugs Survey (CSTADS) 2021-2022 Public Use Microdata File (PUMF) ",f6761337-47e9-455a-a3c4-ea8516aa634f,CSTADS 2021-2022 PUMF Data,23661850
+hc-sc,1f15ca45-8bfd-4f9c-9ec6-2c0c440e69c2,"Canadian Student Tobacco, Alcohol and Drugs Survey (CSTADS) 2021-2022 Public Use Microdata File (PUMF) ",ebdc36e1-910d-4685-81a3-6acfe44729bc,CSTADS 2021-2022 PUMF BSWTS Data,394274170
+hc-sc,1f8d838e-f738-4549-8019-edfc0d931cd7,Cannabis Market Data,2f960711-2447-472d-81b0-731fdfbf59a1,Cannabis market data - Inventory and Sales,69986
+hc-sc,1f8d838e-f738-4549-8019-edfc0d931cd7,Cannabis Market Data,f34a50c5-bbb5-40a1-ae40-bf2a94b338bc,Cannabis market data - Licensed area and cannabis employment,3595
+hc-sc,1f8d838e-f738-4549-8019-edfc0d931cd7,Cannabis Market Data,caf0972d-602f-4365-bcfb-46c315989f19,Cannabis market data - Licensed area and cannabis employment,3518
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,eee8e8cb-479b-4444-ba6c-c48e6d6f2666,CPPD benefits terminated by age group,610
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,e27f24f3-77eb-4389-9cd9-63d1fcdd32d0,CPPD benefits terminated by age group,614
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,2366ee78-94e9-4513-a5ea-51ee9e239c7c,CPPD benefits terminated by gender,252
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,03d61ab1-e0ff-4336-b8fb-70f08be5ba09,CPPD benefits terminated by gender,268
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,a294d99b-700b-4bc7-a8d0-017d1bbb8545,CPPD benefits terminated by province,934
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,c32ca689-6eb2-4abe-ba32-4dfcfaa0245a,CPPD benefits terminated by province,944
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,daf3e935-4e6d-4791-b401-b0056cae835f,CPPD benefits terminated due to a return-to-work by age group,539
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,7506bb99-87ab-4396-9072-9fe8bc37fe36,CPPD benefits terminated due to a return-to-work by age group,542
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,0f38515f-50ce-494f-8d41-fcb335054e95,CPPD benefits terminated due to a return-to-work by gender,224
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,80412a9d-cd99-4a6a-9fda-239b0038264f,CPPD benefits terminated due to a return-to-work by gender,240
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,07af94bd-0f25-4d6f-8f20-01d6dc5e5a85,CPPD benefits terminated due to a return-to-work by province,693
+esdc-edsc,1f9666a9-c603-4794-a354-41c06901bdc8,Canada Pension Plan Disability (CPPD) Benefit Terminations,65ba01e1-a114-4717-aaf2-f2bcb298f9fe,CPPD benefits terminated due to a return-to-work by province,702
+pc,1fd3e4da-df14-4f57-a7a9-b1f3d8df59f8,Snow Cover Duration - Tundra - Vuntut,1aa36d05-d5cf-48e8-a6af-e58273ba4236,Snow Cover Duration - Vuntut,865
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,ec4fc432-812d-4658-b271-829bcf0e1dda,Charities Businesses Directors/Officers,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,e879ebc7-738a-4132-9823-264603649420,Financial data,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,f7583527-8a69-4288-ae01-92168c2f416f,General information ,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,1306bfe7-9f61-4453-9257-1f6b75b507cd,Non-Qualified donees,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,a7eec117-ed4b-48b4-a7bf-80063733e528,Private/Public Foundations,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,aae9c730-64d6-44fb-8e8a-78d00bfe3a23,Activities outside Canada – Countries where program was carried,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,ea2e3f21-bae1-4fa5-96b0-40e30969198b,Activities outside Canada – Details on financial,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,c0dbee31-3886-47ca-9afe-0707ed97b53d,Activities outside Canada - Exported goods,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,f61765e4-aff5-42d7-a84b-485df7247d89,Compensation,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,fbd2eb30-a43b-4407-8346-e09ab35f0da0,Political Activities – Funding,
+cra-arc,206f5517-12c3-40e0-9494-c75d2e410c64,2018 List of charities,222a28b7-3f35-44c4-a900-6a1fdf0e4a75,Political Activities – Resources,
+pc,208965e7-3553-442b-abb0-a79fb6b0f3e7,Harlequin duck abundance - Gros Morne,69707664-78f0-4377-8320-d973fccba5e3,Harlequin duck abundance - Gros Morne - Data,11485
+pc,208965e7-3553-442b-abb0-a79fb6b0f3e7,Harlequin duck abundance - Gros Morne,9c355e7f-aa39-4581-a296-302f4f8597ee,Harlequin duck abundance - Gros Morne - Data dictionary ,262
+pc,20cacad2-e181-4000-887b-9e5e41ac2355,Tree Health - Georgian Bay Islands,c0f38463-ef15-41d1-b638-c7f2962f9705,Tree Health - Georgian Bay Islands - Crown,184227
+pc,20cacad2-e181-4000-887b-9e5e41ac2355,Tree Health - Georgian Bay Islands,5ac14b09-ddd5-4cdf-9de0-24e44abdcd7d,Tree Health - Georgian Bay Islands - Crown - Data Dictionary,2165
+pc,20cacad2-e181-4000-887b-9e5e41ac2355,Tree Health - Georgian Bay Islands,0ae338d8-04a9-4e98-aca7-a219e1eb095e,Tree Health - Georgian Bay Islands - Stem,143103
+pc,20cacad2-e181-4000-887b-9e5e41ac2355,Tree Health - Georgian Bay Islands,f3c5f8d2-6b2f-439a-9784-ee8c29b8eee3,Tree Health - Georgian Bay Islands - Stem - Data Dictionary,3866
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,6bf8981c-923e-42b3-a544-6c5e4e127ce4,Charities Businesses Directors/Officers,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,146eed9a-22a5-4956-a55b-9c60261eb9e9,Financial data,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,c955f3be-3fda-420d-b1a8-426aa152dc0a,General information ,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,d510ae82-0bc5-4b11-8f3d-ed4071a3fe16,Non-Qualified donees,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,6c418925-2249-4d73-942e-d4940fabf474,Private/Public Foundations,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,4bfee7f1-1c4d-4c16-953b-2febefeb0c0a,Activities outside Canada – Countries where program was carried,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,1c468fa2-96e0-4039-9272-af322fdfc8b2,Activities outside Canada – Details on financial,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,9222d946-c4ef-48f2-a7c2-18f33cd5ee9f,Activities outside Canada - Exported goods,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,73933218-6e9c-469f-991a-fae4d5da49e0,Compensation,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,710ab82b-bed2-4666-bde3-d72407e65b2c,Non-cash gifts (gifts in kind) received,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,467af223-8df0-43be-9a3f-73804af7283c,Political Activities – Funding,
+cra-arc,21118663-1847-48ce-81ce-1ac7cff674c0,2019 List of charities,2188adbb-7302-40f5-94d5-e1ac4179ef04,Political Activities – Resources,
+tc,2142e30d-9275-424d-be43-f5cc7ec91916,"Aircraft Fleet: Monthly Fuel Cost and Consumption, by Region or Group",958ae878-72c6-42d8-b59a-f63a6a161b5f,"Aircraft Fleet: Monthly Fuel Cost and Consumption, by Region or Group",35082
+tbs-sct,21ffae40-8e4b-4082-a4f6-3c67f400e126,Data Reference Standard on Person(s): gender,56eed7af-6a70-48d7-a402-4082ebe1e3b5,reference data table for gender,2092
+ssc-spc,2261e96e-9e6f-4a14-8cbb-7dacd51a4d9c,Percentage of Time the Mobile Device Services Cellular Network is Available,f4ce526c-eed9-4b13-9224-be9e6e44b59b,Percentage of time the Mobile Device Services Cellular Network is available,35417
+pc,228bc045-45e2-4a48-b07a-3f31777ffb7b,Elk and moose populations - Elk Island,9496738e-0ad3-4346-a361-e5da4e4b5c9c,Elk and moose populations - Elk Island,50279
+pc,228bc045-45e2-4a48-b07a-3f31777ffb7b,Elk and moose populations - Elk Island,fcbcb9d4-ef02-46ec-b4c9-4a57d68bb5b6,Elk and moose populations - Elk Island - Data dictionary,4714
+psc-cfp,22ad2fe9-311a-4a1a-af04-0d42ebfc3351,Number of employees who do not meet the language requirements of their bilingual positions within the timelines,023b3b49-20e6-4e10-b1c5-89bd6403eed5,Number of employees who do not meet the language requirements of their bilingual positions within the timelines,309
+pc,2304908f-bc3f-4394-bbe7-05293a35868d,Inland Lakes - Water Quality - Pukaskwa,1f05ecc5-80df-4a51-bc22-2b013b4a73e0,Inland Lakes - Water Quality - Pukaskwa,15548
+pc,23694c59-ceec-4042-9e23-370b82e792a2,Lemming Populations - Aulavik,3db7e7bd-1c47-4576-943c-42f9f98c0372,Aulavik - Lemming Populations - data ,1123
+pc,23694c59-ceec-4042-9e23-370b82e792a2,Lemming Populations - Aulavik,d5369311-57c2-4d1a-94e4-08cb8dacfe14,Aulavik - Lemming Populations - data  dictionary,331
+pc,239ddc1d-a2b2-4d18-a161-5a7a42571152,Whitebark Pine Blister Rust - Banff,7459765e-9497-4f94-bf4a-24565eff2724,Whitebark Pine Blister Rust - Banff,7078
+pc,239ddc1d-a2b2-4d18-a161-5a7a42571152,Whitebark Pine Blister Rust - Banff,a09304ca-399b-4ead-9554-c8368ed7a9a3,Whitebark Pine Blister Rust - Banff - Data Dictionary,386
+pc,23a5dd8a-feff-40e4-bf9d-38e6a28b4ade,Open water areal extent and distribution - Elk Island,75d8ce66-9942-4727-9a55-0890f56fe4f5,Open water areal extent and distribution - Elk Island,825
+pc,23a5dd8a-feff-40e4-bf9d-38e6a28b4ade,Open water areal extent and distribution - Elk Island,7eaa86e2-6731-48c1-b84e-b631f33a65b1,Open water areal extent and distribution - Elk Island - Data dictionary,518
+pc,23c8cc50-b180-4de5-b0b8-feefc4c1bf81,Water Quality for Aquatic Health - Terra Nova,6e5a1389-09cc-42f2-a160-a125bf335e8d,Water Quality for Aquatic Health - Terra Nova,67682
+pc,23e44949-fa9f-4547-a01d-939a8255348f,Yoho_NP_Freshwater_Amphibian Visual Surveys,ab89eeb4-40a7-42be-bb2e-0a8b06bb92d5,Freshwater Amphibian Occupancy - Yoho,94348
+pc,243ee856-8d48-4e41-9392-0fae498db28e,Purple Loosestrife - Prince Edward Island,dea14f79-7b0f-40c8-932c-5ee20203b5ba,Purple Loosestrife - Prince Edward Island,12550
+pc,243ee856-8d48-4e41-9392-0fae498db28e,Purple Loosestrife - Prince Edward Island,9227323a-df82-413d-8a96-318218edb130,Purple Loosestrife - Prince Edward Island - Data Dictionary,473
+pc,2473a736-68b7-479f-b359-c5ccbc5c3e11,Situation of the commercial lobster fishery - Forillon,b0561ee9-56c2-43bd-8099-3d846077e065,Situation_of_the_commercial_lobster_fishery - Forillon - Data,2529338
+pc,2473a736-68b7-479f-b359-c5ccbc5c3e11,Situation of the commercial lobster fishery - Forillon,5a37b294-ca39-4b6b-88b5-02a9b557e939,Situation_of_the_commercial_lobster_fishery - Forillon - Data dictionary,1627
+tc,24bb7612-4483-43cd-a469-11d8d4c20f2e,Hazardous Waste Station Audits,9e4a87ba-6965-48f0-9514-53c48efad21c,Hazardous Waste Station Audits,2186
+cfia-acia,24cf9373-3d8b-4653-9d7d-effeaddc3748,CFIA-Undeclared allergens and gluten in coconut water - 2021-2022,f429d820-3415-4a1c-b640-08d7af675c53,CFIA-Undeclared allergens and gluten in coconut water - 2021-2022,156289
+pc,258c2f60-35a6-40d6-a1f5-ed8830438b67,Seedling Rate - Waterton Lakes - Conservation and Restoration Project (Five needle pine),beed23e9-7afc-4d67-a9c4-bd4fd0ce011b,Seedling Rate - Waterton Lakes - Five-needled pine data - 1,416
+pc,258c2f60-35a6-40d6-a1f5-ed8830438b67,Seedling Rate - Waterton Lakes - Conservation and Restoration Project (Five needle pine),62f97b16-8ce7-405c-aff4-d277a7a87362,Seedling Rate - Waterton Lakes - Five-needled pine data dictionary  - 2,289
+pc,25a5de7a-8b9e-42f2-b7bb-5b1b434ae9a5, Forest change - Terra Nova,69d50472-b8ff-42a9-a324-e26f1d98d970, Forest Landscape Regeneration - Terra Nova,597
+pc,25a5de7a-8b9e-42f2-b7bb-5b1b434ae9a5, Forest change - Terra Nova,7e194a15-f915-4fa8-b410-a8c2e4579a5f, Forest Landscape Regeneration-2,619
+pc,25a5de7a-8b9e-42f2-b7bb-5b1b434ae9a5, Forest change - Terra Nova,9d62f9e8-f00e-4c51-baf6-95d05c02bc6a, Forest Landscape Regeneration-3,305
+pc,25a5de7a-8b9e-42f2-b7bb-5b1b434ae9a5, Forest change - Terra Nova,44bb14d8-ea7d-4438-95bf-ecd62889a534, Forest Landscape Regeneration - Terra Nova - Data Dictionary,1535
+pc,25d78543-a5ca-477a-87ad-3d57e8c4ae91,Stream Water Quality - Thousand Islands,42a59214-8af8-44b8-addb-0bbbd55b31ad,Stream Water Quality - Thousand Islands - Data,48455
+wd-deo,26499305-b80b-46e7-a5ed-7f1740fde41e,Number of communities benefitting from federal public infrastructure investments,c4b6712b-4c1f-4038-8ab8-15538b9953eb,Infrastructure_e.csv,173
+cfia-acia,2669732a-eea8-4360-b81e-e5b27c4c207d,CFIA 2020/2021 National Microbiological Monitoring Program Data,73eca5b4-9257-4d21-86d0-a024eb858b0f,Dairy Products 2020-2021,935578
+cfia-acia,2669732a-eea8-4360-b81e-e5b27c4c207d,CFIA 2020/2021 National Microbiological Monitoring Program Data,7bc6f840-9388-44aa-8b20-b4a1856c8df0,Fish and Seafood Products 2020-2021,10024
+cfia-acia,2669732a-eea8-4360-b81e-e5b27c4c207d,CFIA 2020/2021 National Microbiological Monitoring Program Data,ccc130ad-4051-4dec-bf41-7ac42cf0d544,Red Meat and Poultry Products 2020-2021,2300136
+cfia-acia,2669732a-eea8-4360-b81e-e5b27c4c207d,CFIA 2020/2021 National Microbiological Monitoring Program Data,45bec4ed-dd09-45c0-b6d7-70e492fd1a9c,Processed Fruit and Vegetable Products 2020-2021,26118
+pc,26be864a-8bf0-4f47-908f-8b0a85751464,Moose Abundance - Riding Mountain,a50de897-afed-45ab-834e-7f25a7845a19,Moose Abundance - Riding Mountain,286
+lac-bac,26c48373-e049-44f2-844f-8f7bd04dd10e,Time required to complete the processing of a private archive,b50336d3-bb3a-472b-a916-5d97a7d52ac6,Average time required to complete the processing of a private archive,277
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,425f80cf-2e70-421e-8832-8d67fcd1356e,Public Service Commission's Staffing Dashboard: Veterans Hiring Act 1,5168
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,0065a7ca-6495-45fc-a457-5a27e1a28889,Public Service Commission's Staffing Dashboard: Veterans Hiring Act 2,10120
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,9a671e77-9506-4f48-9f36-ddc2d5f102da,Public Service Commission's Staffing Dashboard: Veterans Hiring Act 3,1806
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,3df3bcf0-bdde-45c0-8a39-158c656da604,Public Service Commission's Staffing Dashboard: Reappointments,117505
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,f11e8387-6ccf-4a84-b738-c2bb0445ef31,Public Service Commission's Staffing Dashboard: Priority,6497
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,d4ad133f-d6c0-46c4-ab17-89c6eb03b788,Public Service Commission's Staffing Dashboard: Outflow,1011770
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,347ba6ff-7c58-4775-ba3a-3a4d9e23eb06,Public Service Commission's Staffing Dashboard: Internal Mobility,536446
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,5456d998-fc83-4871-b6b2-deaff7be5c98,Public Service Commission's Staffing Dashboard: Inflow,1430324
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,bfbecc14-d38e-4605-9218-09bef964643d,Public Service Commission's Staffing Dashboard: Demographics Region,12760727
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,ba48f743-388d-46de-ac6b-4d1a3bc47806,Public Service Commission's Staffing Dashboard: Demographics Group,4421315
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,845143a0-fe5e-459a-9534-10fd688f5b10,Public Service Commission's Staffing Dashboard: Demographics First Official Language,292172
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,bc1f4229-b228-4000-9233-86c763b012ec,Public Service Commission's Staffing Dashboard: Demographics Employment Equity,328624
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,0c1b0f39-adbe-4fe4-8aa6-1d97cdf1dfb3,Public Service Commission's Staffing Dashboard: Demographics Age,2881858
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,e41a2a80-1af8-47d6-b993-c051686bc1fa,Public Service Commission's Staffing Dashboard: Advertisements,5213610
+psc-cfp,26ffad36-ca9b-431c-8f6d-a6df02665e2c,Public Service Commission's Staffing Dashboard,f3d46f61-3523-4b5c-9dee-29ff0d0aced4,Public Service Commission's Staffing Dashboard: Advertisement Types ,484706
+pc,2770949b-043c-4073-bc6c-b38b03a5f528,Benthic Invertebrates - Aulavik,ac89c90e-3e58-42e3-a58a-56f851e70668,Aulavik -Benthic Invertebrates  2008-2016 - data,28340
+pc,2770949b-043c-4073-bc6c-b38b03a5f528,Benthic Invertebrates - Aulavik,9cd75ccc-19c1-453c-a495-bed0f9dbba25,Aulavik -Benthic Invertebrates  2008-2016 - data dictionary,1225
+pc,27f96b81-2af0-4b17-926b-d431375e5278,Canadian Aquatic Biomonitoring  Network-  Kootenay ,3a4209d1-6f75-4029-9539-7c6dc9446cae,Canadian Aquatic Biomonitoring  Network-  Kootenay ,1495
+pc,27f96b81-2af0-4b17-926b-d431375e5278,Canadian Aquatic Biomonitoring  Network-  Kootenay ,a53bbf84-47ef-4284-a12e-f390045c76a2,Canadian Aquatic Biomonitoring  Network-  Kootenay - data dictionary,424
+pc,27fa5915-2e9a-4942-b986-953119c6fae2,Aquatic fish inventory - Jasper,73d78e75-2fb7-42f1-aa5d-01a2b28fb83c,Aquatic fish inventory - Jasper,238249
+pc,27fa5915-2e9a-4942-b986-953119c6fae2,Aquatic fish inventory - Jasper,03b1702d-909b-47ed-9bad-d7d5a0137770,Aquatic fish inventory - Jasper - Data Dictionary,2950
+cfia-acia,28697a77-b339-4aed-a0dd-a7d613d8c31d,"Food Microbiology - Targeted Surveys - 2016 - 2017 Bacterial Pathogens, Parasites and Viruses in Unpasteurized and HPP Juices - Final Report",c7016d11-4bea-42f9-8710-5844399d75d0,"Food Microbiology - Targeted Surveys - 2016 - 2017 Bacterial Pathogens, Parasites and Viruses in Unpasteurized and HPP Juices - Final Report",3091900
+ssc-spc,29017f8f-54ce-42a9-9ff7-61f53d5abee1,Percentage of time IT security services are available,5d711bed-8361-406e-9c49-34561e8d0dcc,Percentage of time IT security services are available,16000
+ssc-spc,29017f8f-54ce-42a9-9ff7-61f53d5abee1,Percentage of time IT security services are available,8f104dca-6a38-4ab1-a6db-071030b50107,Percentage of time IT security services are available,18347
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,02a92b0f-b26d-4fbd-9601-d27651703715,"Number of Visits, Downloads",2929
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,ba980e38-f110-466a-ad92-3ee0d5a60d49,Top 100 Downloaded Datasets (for the month prior),418756
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,5a1b343d-2fea-4c31-8652-f77506e3ea37,Datasets by Department or Agency,23695
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,d9138bac-8f9a-42e3-ac7c-450420c5d272,Datasets Released by Organization by Month ,547490
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,f09148f9-a09b-46ec-bf5b-52f26720f3f3,Datasets Released by Month,28512
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,e06f06a9-d897-4a35-9b73-4c2bc1c2d5cf,Percentages of Site Visits by Province and Territory,690
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,b52ee0b2-f2be-4bc5-a27a-db93a228d38b,Percentages of Site Visits by Country,11836
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,9d395c98-f33f-4d40-9e3b-3d383321c577,Top 20 downloaded Open Information ,96155
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,4ebc050f-6c3c-4dfd-817e-875b2caf3ec6,"Downloads per organization, last 12 months",17869169
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,c14ba36b-0af5-4c59-a5fd-26ca6a1ef6db,"dataset visits per department, last 12 months",45933503
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,b1dfa726-7ed1-4a6b-ae49-77a200abee72,"Open Information downloads per department, last 12 months",438862
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,88c73a5e-905e-4c78-b440-c5d5c3acfea8,Openness rating per dataset,15732708
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,8353523a-8e4e-4cd0-a91e-b42abe2e6ee5,User Ratings,1008718
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,d22d2aca-155b-4978-b5c1-1d39837e1993,Datasets that have been deleted,990157
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,15eeafa2-c331-44e7-b37f-d0d54a51d2eb,Open Maps Views,4971467
+tbs-sct,2916fad5-ebcc-4c86-b0f3-4f619b29f412,Open Government Analytics,e664cf3d-6cb7-4aaa-adfa-e459c2552e3e,ATI informal requests per summary,61929734
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,192fa2e2-7401-4b20-8b94-be9c21c6a7ee,ASA24 2018 Complete Database,520117
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,e296fa8b-195f-49e4-bbd3-df90defad00b,ASA24 2018 Complete Database,548968
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,83786764-6666-4dd2-80f9-fe859ed162fd,ASA24 Food HEFI,346060
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,181a8688-fd03-4fc1-bed3-da921434e8ae,ASA24 Food HEFI,352908
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,316155b2-ba5e-467a-845a-6e8ca26d5a87,ASA24 Recipes HEFI,273636
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,9e579861-824a-4c20-8b9f-523143602680,ASA24 Recipes HEFI,273636
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,220843f4-1c70-4dab-8efd-139bfd58819a,HEFI 2019 Cat CNF,718727
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,e6bc9892-15cd-4288-b185-c4ed00731372,HEFI 2019 Cat CNF,718727
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,b044b16f-f371-4631-87fc-0568d0a502d1,HEFI 2019 Cat V2,943909
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,e11191fa-2218-45da-bd18-27210ec72cea,HEFI 2019 Cat V2,943907
+hc-sc,29892c85-2ff5-484c-873c-f494ffba6e1b,The Healthy Eating Food Index 2019 ,1254dc71-aa26-4143-93e7-9343d14f79d0,Recipe Breakdown,2922802
+pc,2a1ef9bb-60f2-4a38-9864-312ff6b43d5f,Snow Cover Duration - Wetlands - Vuntut,330b1a06-3bf2-4e7a-b137-c31d9f1fdf05,Snow Cover Duration - Vuntut,865
+pc,2a55313f-26fc-4872-9a57-2a7bf2a4cc38,Clear Lake Water Quality - Riding Mountain,3bbe193c-53de-4d36-a1f7-208f162059bf,Clear Lake Water Quality - Riding Mountain - data 1,636671
+pc,2a55313f-26fc-4872-9a57-2a7bf2a4cc38,Clear Lake Water Quality - Riding Mountain,b10f7090-f407-4cd1-874e-f0a84ad36d4c,Clear Lake Water Quality - Riding Mountain - data 2,2594954
+pc,2a55313f-26fc-4872-9a57-2a7bf2a4cc38,Clear Lake Water Quality - Riding Mountain,484e9bfc-8dd1-420e-b78b-e02bd491b701,Clear Lake Water Quality - Riding Mountain - data dictionary,19076
+pc,2a8634b5-7a08-47d2-8c81-9816e386080a,Moose and Wolf Abundance - La Mauricie,40364a76-0c77-481a-8230-307d39c9d727,Moose and Wolf Abundance - La Mauricie,1761
+lac-bac,2aeddac2-e351-4e5a-b13f-10f992b724e4,Federal government institutions that participated to an event on recordkeeping,23b318c9-7ba4-4ead-bf58-f7f0b23e5f0c,Federal government institutions that participated to an event on recordkeeping,385
+dfatd-maecd,2af1a7f4-431e-41c7-8c67-fe2348ccf031,COVID-19 Emergency Loan Program,331554f6-7f24-43e5-8d64-59a6afedc262,COVID-19 Emergency Loan Program 2021-05-31,2572
+cfia-acia,2b10a88a-8a0e-4f9b-9cd3-80ef2ff96b4f,Rabies Cases in Canada (2022),ca1285a9-bc99-4d2f-9e6f-317b2e0a463a,Animal Rabies Cases in Canada,
+cfia-acia,2b75a3bd-2d09-4b35-a4d2-617dcbbfacfd,Food Microbiology - Targeted Surveys - 2013 - 2018 Bacterial Pathogens in Multi-Ingredient RTE Foods - Final Report,553594d6-6a27-4cd9-9b49-46cd29e90041,Food Microbiology - Targeted Surveys - 2013 - 2018 Bacterial Pathogens in Multi-Ingredient RTE Foods - Final Report,7197361
+pc,2cacf7fe-08c1-42f8-ba04-f5383fe2c671,Forest Structure - Kluane,a2c84dd3-a9b1-41d9-99c4-b3b15be4dcbc,Forest Structure - Kluane-2,328
+pc,2cacf7fe-08c1-42f8-ba04-f5383fe2c671,Forest Structure - Kluane,35411ae0-2166-4faf-b59c-013e42614328,Forest Structure - Kluane-3,428
+pc,2cacf7fe-08c1-42f8-ba04-f5383fe2c671,Forest Structure - Kluane,4a58f421-fee4-498f-ac62-00cd19621d12,Forest Structure - Kluane - Data Dictionary,331
+pc,2cb85d06-4ebd-4d67-8247-6b74b10348e3,Stream Benthic Invertebrates %EPT - Gwaii Haanas,c848d6ca-3136-4e75-b4df-469c756cab26,Stream Benthic Invertebrates %EPT - Gwaii Haanas,11803
+pc,2cb85d06-4ebd-4d67-8247-6b74b10348e3,Stream Benthic Invertebrates %EPT - Gwaii Haanas,31ff98fd-1ba3-4434-aaaf-9bb73a7d9f6e,Stream Benthic Invertebrates %EPT - Gwaii Haanas - Data Dictionary,2062
+pc,2d60830b-ee2e-4fb5-8c6c-f241f6bf76ba,Forest Area Burned - Prince Albert,2086cc8d-df15-4044-82b5-509227768571,Area Burned - Prince Albert - Data,31360
+pc,2d60830b-ee2e-4fb5-8c6c-f241f6bf76ba,Forest Area Burned - Prince Albert,d35483d7-603e-4f09-9407-7db8848a7b5e,Area Burned - Prince Albert - Data Dictionary,879
+pc,2d9de9e1-fefc-4d9c-9eb8-477ef8484aa9,Westslope Cutthroat Trout - Banff,89f881f7-ad76-4831-8fc1-6370654d4823,Westslope Cutthroat Trout - Banff,1240
+pc,2de2ea61-6bc6-4dc8-9c53-f0260e913e3d,Forest primary productivity - Elk Island,4422b57b-4c6a-4312-8d01-0fb583e1eb7d,Forest primary productivity - Elk Island,1816
+pc,2de2ea61-6bc6-4dc8-9c53-f0260e913e3d,Forest primary productivity - Elk Island,67c2b5ae-d295-4ac1-b8cf-aae59d7b071c,Forest primary productivity - Elk Island - Data dictionary,704
+pc,2e76c473-46df-44c9-82dc-dcaa11a3e71b,Plains Bison - Prince Albert,9a2d6c4d-4352-4622-b7d8-0ae8697586c9,Plains Bison - Prince Albert - Data,24909
+pc,2e76c473-46df-44c9-82dc-dcaa11a3e71b,Plains Bison - Prince Albert,c1cee9f6-1a9c-4fc7-aa72-71f2969897ec,Plains Bison - Prince Albert - Data Dictionary,570
+pc,2ee630e4-6cf5-4aeb-95bb-c9e9f9098cb9,Water Quality Index - Georgian Bay Islands,23031cba-d4fe-45ec-a1ae-38d042cf701b,Water Quality Index - Georgian Bay Islands,38396
+pc,2f2aac73-a8d6-4b21-a9a1-dc321cc1098c, Intertidal Community Similarity - Terra Nova,a4ff469a-671b-4471-aeab-a9eaf636484f, Intertidal Community Similarity - Terra Nova,126836
+pc,2f2aac73-a8d6-4b21-a9a1-dc321cc1098c, Intertidal Community Similarity - Terra Nova,9e4107d5-e149-4d0e-84ff-f53d3425fb9e, Intertidal Community Similarity-2,42687
+pc,2f2aac73-a8d6-4b21-a9a1-dc321cc1098c, Intertidal Community Similarity - Terra Nova,f7250c35-2acb-42d2-84f1-39ee5ca3b230, Intertidal Community Similarity - Terra Nova - Data Dictionary,5692
+pc,2f476985-5d0e-48d6-9fe8-b64c05702534,Water Quality Simplified - Aulavik,b5f133a6-5840-4fa9-bf74-5aab9d234c35,"Aulavik - Water Quality -Simplified  - Nutrients, Physicals and Major Ions - 2015-2016 - data - 1",6346
+pc,2f476985-5d0e-48d6-9fe8-b64c05702534,Water Quality Simplified - Aulavik,b74d3224-a639-4087-8ca6-42a699b95a35,Aulavik - Water Quality -Simplified  - Metals- 2015-2016 - data - 2,9888
+pc,2f476985-5d0e-48d6-9fe8-b64c05702534,Water Quality Simplified - Aulavik,401b4030-2ced-4d19-91ae-698e1e16291a,Aulavik - Water Quality -Simplified  2015-2016 - data dictionary,841
+pc,2f4e52ca-5e93-49d9-af2d-359eb256019c,Peregrine Falcon - Pukaskwa,97dc38de-148f-4c9b-b2d8-1ba0c8437791,Peregrine Falcon - Pukaskwa - Survey Data,140175
+pc,2f4e52ca-5e93-49d9-af2d-359eb256019c,Peregrine Falcon - Pukaskwa,6f13bc50-befd-4f12-9812-71318c672991,Peregrine Falcon - Pukaskwa - Data Dictionary,7202
+pc,2f5d1704-7ada-4a2f-aa0f-35d8e941ff51,Caribou scat - Jasper,5e9a0122-811c-4df5-826e-b47a60d5f311,Caribou scat - Jasper,7726
+pc,2f6c9d7a-7b11-42cd-838c-056c077c4c79,Wetland Invasive Alien Plants - Thousand Islands,9caf8057-3eed-459d-8a49-3604726442fc,Wetland Invasive Alien Plants - Quadrat Method - Data 1,213185
+pc,2f6c9d7a-7b11-42cd-838c-056c077c4c79,Wetland Invasive Alien Plants - Thousand Islands,845232ec-521f-4f43-8263-fea5a94b3ed9,Wetland Invasive Alien Plants - Time Constrained - Data 2,3584684
+pc,2f6e9a6a-0ddd-49a9-864b-0961d1342dfb,Olive-Sided Flycatcher - Kootenay,15415958-a3e5-48e4-b017-a92bacde02ce,Olive-Sided Flycatcher - Kootenay,1951
+pc,2f6e9a6a-0ddd-49a9-864b-0961d1342dfb,Olive-Sided Flycatcher - Kootenay,75a5f199-c12d-4e79-aa12-f65cf88266f3,Olive-Sided Flycatcher - Kootenay - data dictionary,245
+pc,2f6efc92-e024-4b55-9aba-e293639d36d6,Streams and Rivers - Water Quality - Pukaskwa,20cd7932-3af0-4c5b-98be-30c38509ff56,Streams and Rivers - Water Quality - Pukaskwa,113616
+cfia-acia,2fae744b-cb46-4bd4-8ea3-d4e061f2d17a,"Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens in Flavoured Butter - April 1, 2018 to March 31, 2019",ba45c3ae-b077-4978-90b9-395f8c44837c,"Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens in Flavoured Butter - April 1, 2018 to March 31, 2019",63546
+pc,2fc897bd-34e4-4102-afa7-f0a6778a746c,Salmon Thermal Stress - Kouchibouguac,3708ce51-4243-41fa-b146-0a8ae88bff95,Salmon Thermal Stress - Kouchibouguac - Data,15289
+pc,2fc897bd-34e4-4102-afa7-f0a6778a746c,Salmon Thermal Stress - Kouchibouguac,92682152-8313-4b0a-91f3-02e335dd671f,Salmon Thermal Stress - Kouchibouguac - Data dictionary,970
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,3c37d066-9c05-404c-bd80-7413e423828a,"Hiring activities under the Public Service Employment Act, by tenure and fiscal year",3767
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,76a47801-dbda-422c-bc4b-0a0304b05bb9,"Hiring activities and population under the Public Service Employment Act, by geographic area",26727
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,952ee162-1ef9-4c28-9bfd-20e8b02e7f4b,"Indeterminate staffing activities to the public service under the Public Service Employment Act, contributing to movement of indeterminate employees, by fiscal year ",4000
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,31f1217b-506e-4746-a38c-5385a0bf40e9,"Appointments under the Public Service Employment Act of new indeterminate employees, by fiscal year",2879
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,f7324346-53c4-4205-910a-0b70521c7ee2,"Internal staffing activities of indeterminate employees under the Public Service Employment Act, by type and fiscal year",5225
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,f560a4ad-edc9-4bc8-a0ed-2e174bb88d23,"Staffing activities of new indeterminate executive employees under the Public Service Employment Act, by source and fiscal year",7917
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,70c0042e-37d0-49ca-aafc-b21cab7c5555,"Estimates of percentage of appointments under the Public Service Employment Act to and within the public service, by appointment type, process and fiscal year",10470
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,bc3fc632-00dc-47b9-b1a8-2da8d7e776eb,"Post-Secondary Recruitment program highlights, by fiscal year",4482
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,028566a5-b0d7-4d70-9d9b-bb9fe8ea28a3,Staffing activities by type and geographic area,75107
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,34ea0731-9705-4d54-850a-005291dbf063,"Indeterminate and term appointments to the public service under the Public Service Employment Act, by first official language group and fiscal year within and outside the National Capital Region",13904
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,f3a2ad68-e852-4b26-b7fa-a163561cb34a,"Overall hiring and staffing activities to and within the public service, by tenure, previous employment status and geographic area",202969
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,ded1b8b4-df88-4149-87f0-b28c9006e29f,"Staffing activities by type, occupational group and geographic area",3163771
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,f252ee8f-77bd-4c6f-9427-bfba04834e43,"Staffing activities by type, first official language group and geographic area",185554
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,4ae8e18c-3bfe-4386-ac13-c270a1067513,"Student hiring to the public service, by program and geographic area",662725
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,ed783874-8549-42e6-9d4e-ac223c16617e,"Staffing activities by type, organization and geographic area",3822852
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,75d9db1f-86f5-4d72-bf1b-85f500c6d7ac,"Overall hiring and staffing activities to and within the public service, by type, tenure and geographic area",311077
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,14f5dcaa-9223-4981-9245-09773e14ae91,"Appointments to the public service, Post-secondary Recruitment Program, by geographic area",10595
+psc-cfp,2fe6b7f1-fbfe-4aaf-808f-b977d40d44db,Public Service Hiring and Staffing Activities under the Public Service Employment Act,adfef7af-54da-4b2a-880e-0cbe2266e6c1,"Hiring and staffing activities, Recruitment of Policy Leaders",214
+pc,307fce02-71cf-4902-b485-57a70cfafe2b,Lake Trout Catch Per Unit Effort - Kluane,af1e5730-34bd-4314-831c-1d940d99e1a7,Lake Trout Catch Per Unit Effort - Kluane-1,71073
+pc,307fce02-71cf-4902-b485-57a70cfafe2b,Lake Trout Catch Per Unit Effort - Kluane,8cdf4227-afec-4369-babe-05a1f59da7f7,Lake Trout Catch Per Unit Effort - Kluane-2,3154
+pc,307fce02-71cf-4902-b485-57a70cfafe2b,Lake Trout Catch Per Unit Effort - Kluane,71fa0101-91fe-42de-88a1-affc7602854a,Lake Trout Catch Per Unit Effort - Kluane-3,1454
+hc-sc,31599960-2c1e-4d90-a9d9-979ad0e1abb4,"Usual Intakes from Food for Energy, Nutrients and Other Dietary Components ",ce446c74-0c3c-4f52-ba35-48f19d438d58,"Updated Usual Intakes from Food for Energy, Nutrients and Other Dietary Components  ",2966016
+hc-sc,31599960-2c1e-4d90-a9d9-979ad0e1abb4,"Usual Intakes from Food for Energy, Nutrients and Other Dietary Components ",44d4a46f-4386-4036-8e20-7d4b3bd6e4de,"Updated Usual Intakes from Food for Energy, Nutrients and Other Dietary Components  ",3112602
+pc,323a3c89-0e9e-4c84-ae57-80f967182895,Water Quality - Kootenay,cfdb5968-d056-4b9d-8488-c4f3ebb0f07e,Water Quality - Kootenay,691
+pc,323a3c89-0e9e-4c84-ae57-80f967182895,Water Quality - Kootenay,c629c497-5b13-4e95-89bd-90e6bddb7792,Water Quality - Kootenay - data dictionary,1798
+tbs-sct,3282ea92-c145-4e3e-abb4-a5d1a46849fd,Levels of security screening,2c9e8dc9-6ebd-465e-830e-715e27b286c9,dataset,721
+cfia-acia,32e3e6d3-e4f4-4560-82bf-431198486a3c,"Shiga Toxin Producing Escherichia coli in Raw Ground Pork in Canada, 2014-2016",cffa56b2-92a9-4b62-95ad-f8268d149855,"Shiga Toxin Producing Escherichia coli in Raw Ground Pork in Canada, 2014-2016",498181
+ssc-spc,3335c550-9b1d-40ac-8877-e7cfb9198925,Percentage of Time the New Consolidated Data Centre Facilities are Available,be6dece3-b579-4b96-82e6-abb07b13ab63,Percentage of time the new consolidated data centre facilities are available,196635
+ssc-spc,3335c550-9b1d-40ac-8877-e7cfb9198925,Percentage of Time the New Consolidated Data Centre Facilities are Available,063d147b-316d-43c2-ae7e-e5fb53d4a966,Percentage of time the new consolidated data centre facilities are available,178111
+pc,33a7762c-64a6-4705-83b9-2c5eae1873f1,Disturbed Land Revegetation - Waterton Lakes - Conservation and Restoration Project (Fescue),daed99d6-6dba-4f51-8c80-621fd7ccb023,Disturbed Land Revegetation - Waterton Lakes - percent cover and density data 1,87928
+pc,33a7762c-64a6-4705-83b9-2c5eae1873f1,Disturbed Land Revegetation - Waterton Lakes - Conservation and Restoration Project (Fescue),0ef094ae-b57a-4238-a7e3-a684f71d3c9d,Disturbed Land Revegetation - Waterton Lakes - percent cover and density data dictionary 2,902
+pc,33b6077e-46b3-4aa4-befb-2426347efca4,Interior Forest Productivity - Pukaskwa,f5c8b1be-6348-4d58-aec2-828e5e08167a,Interior Forest Productivity - Pukaskwa,9954
+pc,34347f5c-3a07-49ed-aadf-f1c65f8c6685,Tundra Flowering Phenology Mingan,2e21694e-c262-4795-8cb8-3fc6f4f3213a,Flowering date of plants- Mingan-Data,63097
+pc,34347f5c-3a07-49ed-aadf-f1c65f8c6685,Tundra Flowering Phenology Mingan,0c3cc908-fbff-497c-93f7-fc44c2b822fb,Tundra_Flowering_Phenology_Mingan_Data Dictionary,1537
+pc,3437d2de-77f0-45f8-911e-a1067e726aed,Forest Birds - Barred Owl - Cape Breton Highlands,3cb92f34-6846-45e3-8a37-b4a54eb4af16,Forest Birds (Barred Owl) - Cape Breton Highlands - Data,88343
+pc,3437d2de-77f0-45f8-911e-a1067e726aed,Forest Birds - Barred Owl - Cape Breton Highlands,93b7c828-2e61-4866-935b-0deb0440ae5b,Forest Birds (Barred Owl) - Cape Breton Highlands - Site Data,4845
+pc,3437d2de-77f0-45f8-911e-a1067e726aed,Forest Birds - Barred Owl - Cape Breton Highlands,dbafdb2f-0aab-4b9c-92c2-d1a6fc270cb7,Forest Birds (Barred Owl) Cape Breton Highlands - Data Dictionary,6327
+pc,345546e4-24ed-4b03-bff9-ad02548ae865,Lake Water Quality - Kejimkujik,abcb120b-c5dd-43c6-99d5-801175d7d9d8,Lake Water Quality - Kejimkujik - Summary Data - 1,70897
+pc,345546e4-24ed-4b03-bff9-ad02548ae865,Lake Water Quality - Kejimkujik,ee28d7fa-8baa-4b60-9b9c-975b0a8d5f15,Lake Water Quality - Kejimkujik - Data Dictionary,3169
+ssc-spc,34884260-2021-4d39-84e3-16468a278611,Percentage of Software Requests Fulfilled Within Established Service Level Standards,435c5119-32e8-4542-8d4c-d63d27b41695,Percentage of software requests fulfilled within established service level standards,3544
+ssc-spc,34884260-2021-4d39-84e3-16468a278611,Percentage of Software Requests Fulfilled Within Established Service Level Standards,bd742248-114d-40f0-90bc-379e22c88d13,Percentage of software requests fulfilled within established service level standards,3619
+isc-sac,34b3aa67-dd04-455b-996f-9d9b5032ed39,Results of the mandatory minimum 5% Indigenous procurement target for fiscal year 2022-2023,e2359e4c-ac72-4935-8fe1-70285c14c0ea,Results of the mandatory minimum 5% Indigenous procurement target for fiscal year 2022-2023,15043
+pc,34bd1246-e25c-4473-8598-bec160911c64,Marsh Birds - Thousand Islands,47f03418-a0be-4353-aff7-bfcc756df4a1,Marsh Birds - Thousand Islands - Data,234475
+pc,3571474b-8d75-491d-816e-f84677b81a7c,Eastern Red-Backed Salamander - Bruce Peninsula,18cac61e-b5b9-45aa-a043-5f5c9d8923f3,Eastern Red-Backed Salamander - Bruce Peninsula,1205230
+pc,3571474b-8d75-491d-816e-f84677b81a7c,Eastern Red-Backed Salamander - Bruce Peninsula,ad59d00d-b1d0-4e4f-ac45-f460542d95dd,Eastern Red-Backed Salamander - Bruce Peninsula - Data Dictonary,1496
+pc,35991c1c-20d4-4543-8165-c54b3a7d5990,Lake and Stream Trophic State Index - Riding Mountain,cdcfb4d3-d50b-473a-8684-6917cfae0ef4,Lake and Stream Trophic State Index - Riding Mountain,157517
+pc,35a22b06-36fa-4ddc-8e09-c560830b0851,Forest area burned - Elk Island,fc6633ba-9b55-4fe5-b381-64c073db8f80,Forest area burned - Elk Island,8694
+pc,35a22b06-36fa-4ddc-8e09-c560830b0851,Forest area burned - Elk Island,5430f8d5-8c8e-4f66-b4ae-2e0b151d647a,Forest area burned - Elk Island -  Data Dictionary,2486
+pc,35cec21a-1316-4c05-92d8-7cfeb2d6c130,Water Quality - Aulavik ,a4bf8230-848d-404e-8053-c365f34b365b,Aulavik -Water Quality - Total Metals - 2003-2016 - data - 1,2798
+pc,35cec21a-1316-4c05-92d8-7cfeb2d6c130,Water Quality - Aulavik ,e7466171-13cb-4f66-9138-56e204be4c6a,Aulavik -Water Quality - Dissolved Metals - 2003-2016 - data - 2,2677
+pc,35cec21a-1316-4c05-92d8-7cfeb2d6c130,Water Quality - Aulavik ,88bc9e16-6d53-40a7-9629-a1e8fdc688fb,"Aulavik -Water Quality - Nutrients, Physicals and Major Ions - 2003-2016 - data - 3",2600
+pc,35cec21a-1316-4c05-92d8-7cfeb2d6c130,Water Quality - Aulavik ,3b3e4498-dbc6-4f16-9104-6c892ccfaaa3,Aulavik - Water Quality -  2003-2016 - data dictionary,929
+pc,36228fda-d442-4364-9810-cd77c376a851,Beaver Abundance - Riding Mountain,ba0c2417-bf52-4ed1-8fb6-dafd528452b5,Beaver Abundance - Riding Mountain,515
+phac-aspc,3632f9e8-22e3-41c6-843f-7ccfaa1128ef,Health of People in Canada Dashboard​,7e0baeb3-d7d4-48ca-976a-af7629d297f6,Benchmark,290646
+phac-aspc,3632f9e8-22e3-41c6-843f-7ccfaa1128ef,Health of People in Canada Dashboard​,98ca778f-7733-46f7-a193-624752600872,Benchmark,290787
+pc,36724e90-49cd-4ac2-9176-600fa4ec7ddc,Intertidal Bivalves - Pacific Rim,29748fba-6630-40cc-abcd-19abe35bb6c3,Intertidal Bivalves - Pacific Rim - Clams - Data,145807
+pc,36724e90-49cd-4ac2-9176-600fa4ec7ddc,Intertidal Bivalves - Pacific Rim,8573174a-99bf-4f25-acaa-59dc4482274c,Intertidal Bivalves - Pacific Rim - Oysters - Data,29441
+pc,36724e90-49cd-4ac2-9176-600fa4ec7ddc,Intertidal Bivalves - Pacific Rim,a358a144-c824-4687-99c0-fdb6faa6f16d,Intertidal Bivalves - Pacific Rim - Data Dictionary,1226
+pc,36d60e3c-49ee-4d50-8a95-e76469753fd1,Wetland Hydrology - Prince Edward Island,05dcf2e9-e2ee-42bc-924c-66aecc73d9d3,Wetland hydrology - Prince Edward Island,21987279
+pc,36d60e3c-49ee-4d50-8a95-e76469753fd1,Wetland Hydrology - Prince Edward Island,2582f254-37f5-46b9-a77c-c1f329dd39e0,Wetland Hydrology- Prince Edward Island - Data Dictionary,275
+pc,3732ac14-e30c-4128-b8f0-5b9281c6b719,Stream Fish Occupancy - Waterton Lakes - Freshwater,cd7769d5-82c6-46d4-9ed0-d79fe02913b9,Stream Fish Occupancy - Waterton Lakes - electrofishing data - 1,7397
+pc,3732ac14-e30c-4128-b8f0-5b9281c6b719,Stream Fish Occupancy - Waterton Lakes - Freshwater,28491425-405f-4c0f-a55a-ae4e162d24c5,Stream Fish Occupancy - Waterton Lakes - electrofishing data dictionary - 2,618
+pc,37f9a1c6-62c3-4edd-8917-93e204da287d,Chestnut-collared Longspur Abundance - Grasslands,4e29a8bc-c24e-4ccc-bc10-f91443387394,Chestnut-collared Longspur Abundance - Grasslands,316755
+pc,37f9a1c6-62c3-4edd-8917-93e204da287d,Chestnut-collared Longspur Abundance - Grasslands,56dbdce0-62b8-4e59-bef3-913e0bf47482,Chestnut-collared Longspur Abundance - Grasslands - Data Dictionary,1090
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,31aa32e0-f698-4ffd-a01d-e7e4e7ce5b12,Charities Businesses Directors/Officers,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,b6f56870-2f94-479d-92cd-9e6dedfea1d6,Financial data,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,d1946bfc-c340-498d-9ac6-187a75ae3426,General information ,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,7e83ebf7-cc9d-4c70-bc3d-478205506433,Non-Qualified donees,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,17b8e902-c695-47ab-bbaf-dc45eb6eff8e,Private/Public Foundations,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,eb71fab0-f01b-4417-8f0e-262c2669b9df,Activities outside Canada – Countries where program was carried,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,1b5f114b-22d0-48fc-847b-723418ef72bf,Activities outside Canada – Details on financial,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,0859745c-3e7d-4e76-a866-235533b4b55a,Activities outside Canada - Exported goods,63226
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,c8ea8b95-fdad-4e8f-a595-73bc4bb1ee32,Compensation,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,2707c05a-689c-4c9d-84d1-c56128f0d5a5,Non-cash gifts (gifts in kind) received,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,09804f27-7abe-48a2-88dd-2cc242f2925f,Political Activities – Funding,
+cra-arc,38a2cce2-3639-43f9-ab59-8097b202e57e,2017 List of charities,31e523be-aa0a-4c52-a3a9-04acdbb01d38,Political Activities – Resources,93494
+pc,38d3bcaf-68a7-459f-ac4c-da7adef66779,Frog and Toad Monitoring - Thousand Islands,bc09c60e-4d87-4e16-9f32-1e628573de2f,Frog and Toad Monitoring - Thousand Islands - Data,113403
+pc,38d3bcaf-68a7-459f-ac4c-da7adef66779,Frog and Toad Monitoring - Thousand Islands,b5cf6157-89e4-4593-8387-9877b7cad9c4,Frog and Toad Monitoring - Thousand Islands - Data Dictionary,1081
+esdc-edsc,390ee890-59bb-4f34-a37c-9732781ef8a0,Historical minimum wage rates in Canada,2ddfbfd4-8347-467d-b6d5-797c5421f4fb,Historical Minimum Wage Rates in Canada,18822
+pc,39492503-657a-482f-95b3-ef47dab0da77,Forest_stands - Forillon,4579f976-9403-42e2-8459-6163534bd743,"Forest_stands - Forillon - Data, decomposition - 2 ",104431
+pc,3953fc63-40f7-4dce-bb56-dd60f1ca6544,Erosion and Deposition - Point Pelee,bcafed8b-5f6e-4bad-96a9-d69aa5b7d66f,Erosion and Deposition - Point Pelee - Monitoring Data,641
+tbs-sct,39954bc7-ff7a-4180-8b6e-b02bee35078a,Experimentation Inventory,07151ad9-52e2-4f99-b4fd-7cd208816a64,Experimental Inventory,78035
+dnd-mdn,3a0b1de7-060c-4e40-afbf-d2bf476a1fb1,Percentage of Canadian Armed Forces families who feel they meet the challenges of military life,3c74d41c-d639-4b52-bce4-b50646b93409,% of CAF families who feel they meet the challenges of military life,2380
+tbs-sct,3ac0d080-6149-499a-8b06-7ce5f00ec56c,GC Service Inventory,c0cf9766-b85b-48c3-b295-34f72305aaf6,Service Identification Information & Metrics (2024),3060805
+tbs-sct,3ac0d080-6149-499a-8b06-7ce5f00ec56c,GC Service Inventory,8736cd7e-9bf9-4a45-9eee-a6cb3c43c07e,Service Standards & Performance Results (2024),2034522
+tbs-sct,3ac0d080-6149-499a-8b06-7ce5f00ec56c,GC Service Inventory,3acf79c0-a5f5-4d9a-a30d-fb5ceba4b60a,Service Identification Information & Metrics (2018-2023),14009936
+tbs-sct,3ac0d080-6149-499a-8b06-7ce5f00ec56c,GC Service Inventory,272143a7-533e-42a1-b72d-622116474a21,Service Standards & Performance Results (2018-2023),8848467
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,466d8829-968e-498a-a155-e42a3133f644,Population of the federal public service by executive level,3963
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,9ceb08ca-55c7-4a04-9819-7d49759083cb,Population of the federal public service by executive level,3975
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,16c75ddc-475b-4e62-b883-d5517181c9cf,Population of the federal public service executives and non-executives by department or agency,169312
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,06890686-ef92-41f2-877b-d481bccef120,Population of the federal public service executives and non-executives by department or agency,204054
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,438804ac-d19f-4dda-9499-f456daa3cb27,Population of the federal public service by region of work and executive level,50539
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,37e3692c-2dc1-4e14-9623-09f47f0d425a,Population of the federal public service by region of work and executive level,53682
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,dcf0e800-a624-426e-9215-70509861850b,Population of the federal public service by province or territory of work and executive level,80428
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,b9b8a079-ab4d-477f-9a31-b0e16a2cb126,Population of the federal public service by province or territory of work and executive level,84900
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,cbc448b6-0007-4838-819b-a388b642f1fe,Population of the federal public service by age band and executive level,23216
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,573023d1-5aa9-42fa-80c5-3d84923a260a,Population of the federal public service by age band and executive level,25802
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,75d1070e-b94d-4e73-b8ff-99ba7304798c,Population of the federal public service by sex and executive level,7513
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,2b3a74b5-f87f-4544-9d30-de261d48ef83,Population of the federal public service by sex and executive level,8488
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,90739ef5-3a92-4484-85e4-9ad4533fc239,Population of the federal public service by first official language and executive level,8388
+tbs-sct,3aeb9234-2cce-4495-970e-a177d23199ae,Federal public service executive and non-executive statistics,efa475ff-75b5-4f6a-94f7-c2e7ba7a00a6,Population of the federal public service by first official language and executive level,9239
+pc,3b07675c-1ac6-48f1-800d-e12eaaaee949,Banff_NP_ForestAlpine_Songbird Point Counts ,5183f1e4-33fa-4f8a-993f-e7c8cef09dc5,Avian Species Abundance - Data,3863107
+pc,3b07675c-1ac6-48f1-800d-e12eaaaee949,Banff_NP_ForestAlpine_Songbird Point Counts ,e72db018-e5c5-4614-9f0e-df345a5ed57e,Avian Species Abundance - Data Dictionary,14446
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,9436df93-fe2d-4e78-8fd2-9fa8dc51c7bf,Sealed Source Tracking System – 2017 (English),9076365
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,5745b0de-7e69-4093-8e99-852d27120645,Sealed Source Tracking System – 2017 (French),9756897
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,b4148cd1-89b5-4ebf-ad55-e7e985ced9fa,Sealed Source Tracking System – 2018 (English),8431914
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,8988886f-c8e9-4452-a968-66f2b3e6b6ae,Sealed Source Tracking System – 2018 (French),8802429
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,aca4ed87-4fed-42f1-996c-3c6c2b08d999,Sealed Source Tracking System – 2019 (English),8001819
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,91fcde92-7ca2-4ceb-b26d-9ecc8a91a27c,Sealed Source Tracking System – 2019 (French),8357770
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,cca0fdef-30d7-457d-a2b4-5cc366179b68,Sealed Source Tracking System – 2020 (English),4542395
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,27d87381-8d7b-4765-8639-2fffd5eb547d,Sealed Source Tracking System – 2020 (French),4967527
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,147a1943-63d0-423d-90eb-73aa1c5bbe92,Sealed Source Tracking System – 2021 (English),4472428
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,bf5bf086-0c24-43e5-8156-f8978fa8e847,Sealed Source Tracking System – 2021 (French),4860714
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,65586017-d50f-4ff9-bfcd-b612c32e21d4,Sealed Source Tracking System – 2022 (English),4790227
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,29a2c99a-ab5f-47d7-9868-73f3f4bb9497,Sealed Source Tracking System – 2022 (French),5221681
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,8ef4aeb6-25b9-4f99-b9a0-b5b7b86c6ea4,Sealed Source Tracking System – 2023 (English),3793757
+cnsc-ccsn,3b119925-fd22-4b1b-a01f-7e83e7d5900b,Sealed Source Tracking System,a7bd2d3a-d5f0-458c-94ce-524493d8e805,Sealed Source Tracking System – 2023 (French),4113990
+pc,3bad5ce0-0b16-43ee-be32-78cc2f64843f,Benthic Invertabrates - Ivvavik,c8cc8eb8-bfdb-4d0b-b205-d7006ab5bf1c,Benthic Invertabrate - Ivvavik - 2008-2016 - data ,20958
+pc,3bad5ce0-0b16-43ee-be32-78cc2f64843f,Benthic Invertabrates - Ivvavik,29c39a94-96d6-4a4f-afa0-6180ae0b817e,Benthic Invertabrate - Ivvavik - 2008-2016 - data dictionary,2461
+esdc-edsc,3bcb3cd0-296b-4095-96a3-c8bb17495e47,"Average monthly payments for Canada Pension Plan (CPP) disability beneficiaries by age group, gender and calendar year ($)",60f4c2ca-92c0-4960-ac4c-7be888a7456f,"Average monthly payments for Canada Pension Plan (CPP) disability beneficiaries by age group, gender and calendar year",2304
+esdc-edsc,3bcb3cd0-296b-4095-96a3-c8bb17495e47,"Average monthly payments for Canada Pension Plan (CPP) disability beneficiaries by age group, gender and calendar year ($)",c94d10e8-f8cf-4d7d-95bc-2672b370e921,"Average monthly payments for Canada Pension Plan (CPP) disability beneficiaries by age group, gender and calendar year",2494
+wd-deo,3c570e08-5b93-46ce-be97-d6770892efd4,"Percentage of small and medium-sized enterprises that are majority-owned by Indigenous people, youth, visible minorities and persons with disabilities in western Canada",b44c29af-a4a4-4821-9de7-cb6cfecd0c8c,Business Ownership_e.csv,111
+pc,3ce250b3-75bc-48f9-9c2d-addfda3d6804,Snowbed meltout phenology - Gros Morne,74a61579-397b-465f-8d28-92f63cbcbb6a,Snowbed meltout phenology and status of herb willow in late snowbeds - Gros Morne,20632
+pc,3dab77d0-b16a-4cd9-b06a-1a2185d0499e,Forest Non-Native Vegetation - Banff,bf8ff48f-ddf0-453b-a7fc-3c016cf39185,Forest Non-Native Vegetation - Banff,4141
+pc,3dab77d0-b16a-4cd9-b06a-1a2185d0499e,Forest Non-Native Vegetation - Banff,2f0b3b0f-b680-40fe-bc6a-ef460760b8f6,Forest Non-Native Vegetation - Banff - Data Dictionary,1908
+pc,3e47aec0-3319-42d2-ac71-d50bd2527cbf,Terrestrial Birds - Waterton Lakes - Forest,3a632f68-2310-4c7e-b475-43196a871e9c,Forest Birds - Waterton Lakes - Bird Diversity and Abundance data - 1,898080
+pc,3e47aec0-3319-42d2-ac71-d50bd2527cbf,Terrestrial Birds - Waterton Lakes - Forest,468a5169-a1ee-4038-8691-03431e6eb476,Forest Birds - Waterton Lakes - Bird Diversity and Abundance data dictionary - 2,8092
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,9b2d0f3d-9b66-401d-a551-863ec27414c1,Charities Businesses Directors/Officers,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,93544c86-0458-448a-adac-fff195c4f42c,Financial data,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,be944ec3-c8c7-42ed-a9f7-8c9b7c023276,General information ,10008246
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,fd2931b4-3b1a-4252-a8a8-4c4218eda613,Non-Qualified donees,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,80e3c7f9-e3b9-43d0-9053-f7359c305dcb,Private/Public Foundations,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,6f052d29-443b-4cce-a0e2-eac8225d976c,Activities outside Canada – Countries where program was carried,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,07e21c04-e95e-4576-9847-828b28cb3788,Activities outside Canada – Details on financial,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,8ef9fc37-aa8f-4099-8f1e-9827d2a0cd03,Activities outside Canada - Exported goods,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,ec4d4a94-6eb6-4c05-b618-754f7f2bc78c,Compensation,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,cc3154e8-c7b3-4be7-b7af-c2b2b62d481e,Political Activities – Funding,
+cra-arc,3e8a4d9f-9a12-4498-9a0b-a5c81d3281b4,2021 List of charities,e1330d89-e981-43ee-a9e3-017170ad7816,Political Activities – Resources,
+tbs-sct,3ec8780d-54e0-46db-9eaf-f838a27389d1,Broken Links Report,1f1b0e53-40cc-4900-a08a-e5595697aaea,Broken Link,4606528
+psc-cfp,3f19e2bc-b243-486f-b536-1a03a4d93ad6,"Public servants who received permission from the Public Service Commission to seek nomination as, and be, a candidate in a federal, territorial, provincial and municipal election",8440d413-a122-4eac-9627-5810bfdb73f4,"Public servants who received permission from the Public Service Commission to seek nomination as, and be, a candidate in a federal, territorial, provincial and municipal election (Apr. 1, 2023 - Mar. 31, 2024)",3512
+cra-arc,3f53ffb8-c299-4fc7-96a0-4e9dfd01d43d,Goods and Services/Harmonized Sales Tax Credit Top Up Entitlement Data by Federal Electoral District - April 2020,d60b565e-63d3-434e-8cf2-437479a414cd,Explanatory Notes,690
+csec-cstc,3fb07d1b-8521-4c9a-b7de-6695f46b0d80,"CSE Workforce Representation as of June 30th, 2022",b629fe88-c760-47cc-afff-87915a290de4,CSV EN,503
+psc-cfp,3fe41e48-850e-4df2-81db-9df16d3c56a5,Federal Student Work Experience Program (FSWEP) Requests for Referrals submitted by hiring departments,51e8f1c1-7f2b-4245-900a-2304342410c0,FSWEP Requests for Referrals as of 2024-09-30,25139278
+pc,4059a720-0541-42d2-8ce6-92bd5c030b1d,Air Quality - Mount Revelstoke,f8b4bc6c-0a19-471d-a84a-b647ebfcbe89,Air Quality - Mount Revelstoke,1391
+pc,4059a720-0541-42d2-8ce6-92bd5c030b1d,Air Quality - Mount Revelstoke,e307891a-1738-4c26-8edf-9b30ad71a375,Air Quality - Mount Revelstoke - data dictionary,2986
+pc,40ae1d02-b4a1-41bf-98f2-6e619dea850a,Kelp Density - Pacific Rim,29cba2c1-ebdb-47b7-8ee5-dcd09cd9ba24,Kelp Density - Pacific Rim - Data,204222
+pc,40ae1d02-b4a1-41bf-98f2-6e619dea850a,Kelp Density - Pacific Rim,c0660f94-a306-4344-af31-30f919ae0949,Kelp Density - Pacific Rim - Data Dictionary,898
+pc,4107dc81-79c0-406e-a1e6-301509d9e506,Kokanee Spawning Counts - Kluane,902efb46-37c9-4bab-bd86-19021ce9fc2b,Kokanee Spawning Counts - Kluane,2276
+pc,417ab00e-070f-4647-81f8-434048eab3cb,Estuarine Index of Biotic Integrity - Kouchibouguac,fbc719e6-b4f9-4fce-a1f7-c018700b5f5c,Estuarine Index of Biotic Integrity - Kouchibouguac,10150
+pc,418c81fa-60bd-4063-a526-050c4032ecd1,Mammal Diversity and Abundance - Prince Albert,bce07fe7-69e1-4239-9522-bd98d963c465,Mammal Diversity and Abundance - Prince Albert - Data,4617010
+pc,418c81fa-60bd-4063-a526-050c4032ecd1,Mammal Diversity and Abundance - Prince Albert,74ce639a-06d9-4dd4-aadd-d17c48311a58,Mammal Diversity and Abundance - Prince Albert - Data Dictionary,4117
+pc,42de6c1a-6826-4197-bc35-3e099cc9a6f6,Forest trees - Kejimkujik,629cf5b3-c8c9-4746-bfc3-14e9d6a587b2,Forest Trees - Kejimkujik - Condition Data - 1,52949
+pc,42de6c1a-6826-4197-bc35-3e099cc9a6f6,Forest trees - Kejimkujik,7f53f65d-6352-4a6c-8095-bb8876333a2f,Forest Trees - Kejimkujik - Site Information Data - 2,673
+pc,42de6c1a-6826-4197-bc35-3e099cc9a6f6,Forest trees - Kejimkujik,ba54dd2b-6413-46ca-83fa-32571babb89a,Forest Trees - Kejimkujik - Data Dictionary - 3,2762
+cnsc-ccsn,42f3db24-390d-4d53-a0fa-108dca0a3200,Darlington Relicensing - Information and Reports,1f2cfdb6-9d04-4eca-a56f-3455e8df3d23,Darlington Relicensing - Information and Reports - Registry of Substantive Documents for Darlington Relicensing Project,1090
+tbs-sct,4301f4bb-1daa-4b50-afab-d1193b5d2284,2020 Public Service Employee Survey,83b8d566-8199-40a3-9d87-6b99e9600c5b,Subset 1 - 2020 Public Service Employee Survey open dataset - with labels,27409789
+tbs-sct,4301f4bb-1daa-4b50-afab-d1193b5d2284,2020 Public Service Employee Survey,12d848dd-568d-41b6-8a78-09d898541f07,Subset 2 - 2020 Public Service Employee Survey open dataset - with labels,389208456
+tbs-sct,4301f4bb-1daa-4b50-afab-d1193b5d2284,2020 Public Service Employee Survey,63f972a8-8bf2-4584-a735-e5d0c07a9eb6,Subset 3 - 2020 Public Service Employee Survey open dataset - with labels,874749173
+tbs-sct,4301f4bb-1daa-4b50-afab-d1193b5d2284,2020 Public Service Employee Survey,56d0ebe0-4353-493f-889a-b9ab36259751,Subset 5 - 2020 Public Service Employee Survey open dataset - with labels,820232802
+tbs-sct,4301f4bb-1daa-4b50-afab-d1193b5d2284,2020 Public Service Employee Survey,b9363aab-8906-45b3-91b5-c91cae5a9327,Subset 6 - 2020 Public Service Employee Survey open dataset - with labels,328431638
+tbs-sct,4301f4bb-1daa-4b50-afab-d1193b5d2284,2020 Public Service Employee Survey,8bf75d4b-a80d-4828-839a-bf8c0b76af51,2020 Public Service Employee Survey open dataset,296559376
+tbs-sct,4301f4bb-1daa-4b50-afab-d1193b5d2284,2020 Public Service Employee Survey,6e430653-54ee-4e96-8af3-a44c9c2cfea1,Subset 7 - 2020 Public Service Employee Survey open dataset - with labels,447424342
+tbs-sct,432527ab-7aac-45b5-81d6-7597107a7013,Proactive Disclosure - Grants and Contributions,1d15a62f-5656-49ad-8c88-f40ce689d831,Proactive Disclosure - Grants and Contributions,1885297351
+tbs-sct,432527ab-7aac-45b5-81d6-7597107a7013,Proactive Disclosure - Grants and Contributions,4e4db232-f5e8-43c7-b8b2-439eb7d55475,Proactive Disclosure - Grants and Contributions Nothing to Report,22362
+pc,4361c613-2f4d-48b0-bf87-8d69a09b091a,Multi-Species Mammal Occupancy - Waterton Lakes - Forest,e4df2452-a881-49ac-8ef2-ba383dab8dd8,Multi-species mammal occupancy - Waterton Lakes - presence data - 1,6592551
+pc,4361c613-2f4d-48b0-bf87-8d69a09b091a,Multi-Species Mammal Occupancy - Waterton Lakes - Forest,d6c5d04c-d3d4-4fcf-9527-8341cdefd750,Multi-species mammal occupancy - Waterton Lakes - presence data dictionary - 2,4685
+pc,43675fb6-6510-4d90-80d0-71f7e96b9604,Annual Decay Rates - Prince Edward Island,0c1cc3d1-29c8-46d9-b881-990ace1a6e8f,Annual Decay Rates - Prince Edward Island,238784
+pc,43675fb6-6510-4d90-80d0-71f7e96b9604,Annual Decay Rates - Prince Edward Island,689c67bf-e3dc-4445-8507-0cf17d3aed38,Annual Decay Rates - Prince Edward Island - Data Dictionary,2130
+pc,43d71c93-0843-407c-a0f2-286716d7da47,Stream temperature - Torngat Mountains,328d27d7-e3a4-432b-9fcb-72cf13dea1c3,Stream hydrology and temperature - Torngat Mountains,10022998
+pc,443c3c4b-ef3b-4a98-8d37-e3ba398609d8,Area Burned Condition Class - Glacier,9fc7f421-60ae-4d9a-a7dd-6bc85ba70264,Area Burned Condition Class - Glacier,26067
+pc,443c3c4b-ef3b-4a98-8d37-e3ba398609d8,Area Burned Condition Class - Glacier,81429a72-0519-4b07-82a0-71b18cda8541,Area Burned Condition Class - Glacier - Data Dictionary,982
+pc,4482fa68-809d-4eaf-87c0-4e3cf404a1e0,Invasive Vascular Plants - Pacific Rim,6e974350-65cc-4d56-9256-6cc7012fcc06,Invasive Vascular Plants - Pacific Rim - English Ivy - Data,660
+pc,4482fa68-809d-4eaf-87c0-4e3cf404a1e0,Invasive Vascular Plants - Pacific Rim,b1e06bfe-a83e-4f7d-939b-9dae97794f0d,Invasive Vascular Plants - Pacific Rim - Invasive Dune Grass - Data,988
+pc,452342cd-409b-4963-8bb6-162bb1d4fee4,Eelgrass extent - Kejimkujik,e8f2150e-eebe-4ab8-8977-aab4098d7acb,Eelgrass Extent - Kejimkujik - Extent Data,644
+pc,4560eba5-a5f6-4c30-be39-d72c3eab8941,Permafrost - Ivvavik,ebda1c50-32eb-41ee-bae8-f822fa691bbd,Permafrost-Ivvavik-2014-2017-data,95201
+pc,45a1955f-3134-4001-90d2-f33d3b2ff1dc,Kootenay_NP_Alpine_Pika Haypile Surveys,246bf163-93df-4bc8-afec-15ada1bf94ca,Alpine Small Mammal Pika - Kootenay,203415
+pc,45d5d92f-8828-4312-8adf-a535c6ffb98a,Permafrost - Tundra -Vuntut,e137993f-8152-4ba4-96c0-563124ad8025,Permafrost-Vuntut,3226
+pc,46ad3419-a510-4e09-8280-679daddd1668,Grizzly Bear Occupancy - Ivvavik,4dc2d3b6-25db-409d-91da-684ef9551ba7,Grizzly Bear Occupancy - Ivvavik - Data,68894
+pc,46ad3419-a510-4e09-8280-679daddd1668,Grizzly Bear Occupancy - Ivvavik,5d604408-5dea-4c52-bde8-a636b87baa31,Grizzly Bear Occupancy - Ivvavik - Data Dictionary,1132
+pc,46c0d3f4-5b52-4d58-90a7-3631060c60bc,Lentic freshwater fish occurrence - Jasper,de14e8df-5753-4910-91b6-8d6888eefbcb,Lentic freshwater fish occurrence - Jasper,9083
+pc,46c0d3f4-5b52-4d58-90a7-3631060c60bc,Lentic freshwater fish occurrence - Jasper,de7e498c-0fd2-4481-9659-2f9d20b4ddaf,Lentic freshwater fish occurrence - Jasper - Data Dictionary,2950
+nrc-cnrc,46c213f2-863f-4fa2-9a14-467f8a75c8e1,National Research Council Canada Publications 2019-2021,250ea304-fbc3-4291-a40a-9e90877ece1b,NRC Publications 2019-2021,4628521
+pc,470fcb2f-2a5d-4407-b3b0-089762cce138,Whitebark pine reforestation - Jasper,e5453da1-12ae-4962-9327-147a374bfc89,Whitebark pine reforestation - Jasper,63816
+pc,470fcb2f-2a5d-4407-b3b0-089762cce138,Whitebark pine reforestation - Jasper,53f736dc-72b3-44e4-a57e-4011d412a175,Whitebark pine reforestation - Jasper - Data Dictionary,1600
+cfia-acia,471bf93a-1f62-46c8-8ffd-9c874e557a7c,Grated Hard Cheese Adulteration Summary Data ,f4003db1-be09-494a-b35a-4aa91544aa40,Grated Hard Cheese Adulteration Summary Data - 2022-2023,1190
+pc,471c5c9d-609a-4f84-9e90-59dfba0c043d, Intertidal Invasive Species - Terra Nova,0b01ef42-8e49-4a69-8766-7a0b5f6ceae3, Intertidal Invasive Species - Terra Nova,7306
+pc,471c5c9d-609a-4f84-9e90-59dfba0c043d, Intertidal Invasive Species - Terra Nova,3391c581-e398-4302-98dc-e6808d96eaac, Intertidal Invasive Species - Terra Nova - Data Dictionary,386
+pc,472d2b20-9304-46bd-a7b5-25cfb98ac1d6,Piping plover - Kejimkujik,0be0ce51-7450-4902-98ff-79c75366229d,Piping Plover - Kejimkujik  -  Breeding Success Data,1818
+dnd-mdn,474c87a7-147d-46d4-9ea6-65151007058d,Enterprise Information Technology Service Management,d5dd0a8a-4a63-4fca-bfc4-2352cf70b8f7,Enterprise Information Technology Service Management,12290
+pch,4838c5e5-b3bb-444b-af3b-36648b60ecf5,"Data on funding provided in 2016-2017 and 2017-2018 by the Canada Cultural Spaces Fund, Canadian Heritage",59592bde-6568-4575-890a-00425190f49a,CCSF_EN,101321
+pc,48a3f8cf-20f3-4a46-9f8a-ed4023d8b333,Forest Breeding Bird Abundance and Composition - Kluane,b7777314-5522-4377-85b4-33d6cd4bb645,Forest Breeding Bird Abundance and Composition - Kluane-1,149950
+pc,48a3f8cf-20f3-4a46-9f8a-ed4023d8b333,Forest Breeding Bird Abundance and Composition - Kluane,7b131bc1-a3ab-421a-91f8-12dd6c97802f,Forest Breeding Bird Abundance and Composition - Kluane-2 Data Dictionary,4609
+fin,48de6bb4-b953-4cb6-bbb5-3de915c23d47,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2021",e28a1093-12c2-4d5c-b736-4a142520aa91,Data tables - metadata,1989
+lac-bac,497fa201-6286-45c1-b4ba-54ab0779d2ea,Cost to describe a newly acquired published title,5ede37fa-b02c-444a-8d22-5c94daa6a459,Cost to describe a newly acquired published title,110
+wd-deo,49b5e5df-fd6b-4009-82f0-265dd2e5de21,Value of business expenditures in research and development by firms receiving WD program funding (in $),f22b006d-749a-4db6-a51a-8b1048f604b0,High Growth Firms_e.csv,191
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,e9b2bfe2-b6bd-401e-9edb-c05367fb3885,Charities Businesses Directors/Officers,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,e22180e3-3fa1-4c24-b9af-29d28c79f9da,Financial data,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,f40f72d2-bdfe-4ec0-ac82-1ba707b45f92,General information ,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,893763b8-7224-4a2e-8f96-c57a42bf2e4a,Non-Qualified donees,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,caa4c44e-7431-4908-a428-364e5c1c383c,Private/Public Foundations,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,3c3cd2e3-b679-4f10-9f33-344dbf0e8a68,Activities outside Canada – Countries where program was carried,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,d821d433-43b6-41ff-a2df-aaf6dd20cf10,Activities outside Canada – Details on financial,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,d2846e45-305b-4a76-9524-213ba475b4fa,Activities outside Canada - Exported goods,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,6df18c92-222f-4c1d-b005-b57e37383d6d,Compensation,
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,edb33b0f-691b-427f-b213-d793518e6b5c,Political Activities – Funding,6511
+cra-arc,49cb599c-03f6-4191-b8d3-fb5b8e35b218,2013 List of charities,6e2341ee-4d0a-4947-b57c-c3ada100756c,Political Activities – Resources,74024
+pc,49d5ba7d-d860-40d9-9183-892979e4acbe,Federal Heritage Designations,29713043-0e7b-404a-986e-3b6dcf33a2bf,Designations 2021-2022,291617
+pc,49d5ba7d-d860-40d9-9183-892979e4acbe,Federal Heritage Designations,4f3adf0e-f99e-4a63-b837-0a0b0f4e387d,Designations 2021-2022,327710
+pc,4a7067e5-2cf0-41e1-b9d9-66fc8248b270,Condition of Contemporary Assets,29df3f8e-da90-49e3-9b59-a564f6c735cb,Contemporary Assets - Condition 2021-2022,2735558
+tbs-sct,4ae27978-0931-49ab-9c17-0b119c0ba92f,"Proactive Disclosure - Annual Expenditures on Travel, Hospitality and Conferences",a811cac0-2a2a-4440-8a81-2994fc753171,"Annual Expenditures on Travel, Hospitality and Conferences",2204235
+lac-bac,4af9c2e1-0d1a-4659-a3ed-b4e9c16fab4e,Annual increase of new digital files preserved (includes both born-digital and digitized documents),d899c6a6-d3d2-4e06-ac97-0c148a803d2a,Annual increase of new digital files preserved (includes both born-digital and digitized documents),211
+pc,4b588729-e690-4f01-a573-d8a4e8eb3b2c,Plant Phenology - Quttinirpaaq,b5012a3f-1438-4180-8a4b-bf48802fcca9,Plant Phenology - Quttinirpaaq - Phenophase Count Data - 1,143920
+pc,4b588729-e690-4f01-a573-d8a4e8eb3b2c,Plant Phenology - Quttinirpaaq,44ec633e-9852-423d-9809-cc082c3193da,Plant Phenology - Quttinirpaaq - Peak Flower Day Data -2,1533
+pc,4b62b583-2166-49b8-8824-0bc76bc3477a,5 Needled Pine - Health transects - Waterton Lakes - Forest,88b0d561-4971-4559-96b1-f096906a9774,Five Needle Pine Health Transects - Waterton Lakes - Blister Rust Data  - 1,6804
+pc,4b62b583-2166-49b8-8824-0bc76bc3477a,5 Needled Pine - Health transects - Waterton Lakes - Forest,09c49804-9954-4537-b379-511ab06d2a50,Five Needle Pine Health Transects - Waterton Lakes - data dictionary - 2,403
+tbs-sct,4b8298dc-e90a-456d-855d-9ad2f7e9e067,Government of Canada position number architecture,761feab2-78c4-4b15-903e-b8d7dcfd7d0d,Reference Data ,123
+pc,4bdefc6d-aca8-42e0-91f4-8e53ebd36a98,Forest Composition - Prince Edward Island,00a89244-9cde-4c1d-a686-60357b82af55,Forest Composition - Prince Edward Island,82874
+wd-deo,4c495642-4168-4149-8366-19bdcb470f2d,Percentage of professional jobs (including science & technology) in western Canada,8eb6b188-beea-4545-b015-b13cc2968b0f,Jobs_e.csv,126
+pc,4c770646-3992-49c1-ae3e-231184c23f5d,Kootenay_NP_Forest_Winter Wildlife Corridor Tracking,1aa46ae3-8ddb-4356-9568-2f1b6f69f13f,Winter Wildlife Corridors - Kootenay,544513
+pc,4d51e33b-c94b-4f18-aea7-91fb8d329c85,Shoreline Dune Plants - Pacific Rim,cd73aad7-7a43-4c08-9563-1f4a1362932d,Shoreline Dune Plants - Pacific Rim - Data,1786
+pc,4dce385b-4b7e-4bce-9c59-4f618dd9c937,Plant Community - Quttinirpaaq,c8e988e2-c6b7-42f9-a1e8-b418a24fe39e,Plant Community - Quttinirpaaq - Plant Community Data - 1,543219
+pc,4dce385b-4b7e-4bce-9c59-4f618dd9c937,Plant Community - Quttinirpaaq,315f1d5a-9e61-4f8e-aa23-7b4983681f27,Plant Community - Quttinirpaaq - Plant Community Data Dictionary - 2,2151
+esdc-edsc,4deb7637-3613-4012-84a2-882b06ab7458,Occupational Injuries in the Canadian Federal Jurisdiction by Province or Territory: 2008-2021,91f255fd-47dc-4b13-b497-54ccfe8b3911,Occupational Injuries in the Canadian Federal Jurisdiction by Province or Territory: 2008-2021,15879
+pc,4e89a304-c282-404a-b025-6604528890c7,Pelican and Cormorant Abundance and Mortality - Prince Albert,f7a78710-8600-49df-8afc-f3c0c654022a,Pelican and Cormorant Abundance and Mortality - Prince Albert,2080
+tc,4eb6f99f-fbe6-43d9-95c1-4c623cc747e5,Recycle Stations and Waste Bins Audits,a5fba6c4-4dcd-4876-92bd-335b634c4710,Recycle Stations and Waste Bins Audits,5499
+tbs-sct,4ed351cf-95d8-4c10-97ac-6b3511f359b7,Open Data Inventory,d0df95a8-31a9-46c9-853b-6952819ec7b4,Open Data Inventory,15702463
+csps-efpc,4f2fedd4-a1be-4440-bac5-d96ee8d71e30,Shape Your Learning,b39f7b34-49d6-43e7-9369-d3b7405e505f,Shape Your Learning Dataset 2021,13233340
+dfatd-maecd,4f6d0489-adea-43ed-a19f-62355d1e9d66,Total daily global percent increase in number of Canadian abroad registrants,fb0a45b7-0479-4e5a-93c5-4f45adc4b793,Total daily global percent increase in number of Canadian abroad registrants,12787
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",bcd5a76c-28e8-4e56-9112-546981b9f312,"Table 1: Personal Income Tax (PIT) gap estimates for tax years 2014 to 2018, in $billions",957
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",48e60ad7-8e8f-4950-861f-9993f2b1ee2d,"Table 1: Personal Income Tax (PIT) gap estimates for tax years 2014 to 2018, in $billions",1584
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",6851704b-1ba0-4d09-a8b3-4be3342e5012,"Table 3: Corporate Income Tax (CIT) gap estimates for tax years 2014 to 2018, in $billions",1043
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",b393ee92-008f-4a02-8769-5be45d711edd,"Table 3: Corporate Income Tax (CIT) gap estimates for tax years 2014 to 2018, in $billions",1591
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",7ac60df9-4629-499e-98ab-d9623d3dc612,"Table 4: GST/HST gap estimates for tax years 2014 to 2018, in $billions",371
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",db36bbbd-e3e3-4d71-b509-70e960abbf7e,"Table 4: GST/HST gap estimates for tax years 2014 to 2018, in $billions",481
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",07365293-6c1f-4036-a583-3198e50acc8c,"Table 5: Excise gap estimates for tax years 2014 to 2018, in $billions",404
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",bbeeb93d-d8fa-42ae-a7ff-121e9289b7f1,"Table 5: Excise gap estimates for tax years 2014 to 2018, in $billions",513
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",52dc54a6-3105-46db-887a-e64009a178c7,"Table A1: Tax gap estimates in nominal dollars for tax years 2014 to 2018, in $billions",1401
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",78ffc6fc-e0c1-445e-96ac-eded85fccc6d,"Table A1: Tax gap estimates in nominal dollars for tax years 2014 to 2018, in $billions",2211
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",404ec58f-4213-47db-abf4-25b39b65a513,"Table A2: Tax gap estimates in constant 2018 dollars for tax years 2014 to 2018, in $billions",1398
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",6d3a4d2e-847a-4fe8-9c35-2cd5b8b7f396,"Table A2: Tax gap estimates in constant 2018 dollars for tax years 2014 to 2018, in $billions",2208
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",4caa9300-7596-4097-a572-6f865c1719ba,Table A3: Tax gap estimates as percentage of corresponding federal tax revenue for tax years 2014 to 2018,1173
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",41fc084d-7cfb-478f-a87a-cd7dd896eeac,Table A3: Tax gap estimates as percentage of corresponding federal tax revenue for tax years 2014 to 2018,1921
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",148c9a18-e5a2-43c4-8420-3c66bb24f622,"Table A4: Federal tax revenue for fiscal years from 2014-15 to 2018-19, in $billions",275
+cra-arc,4f76bbb3-81df-411b-9ad7-d5a5c965e322,"Overall federal tax gap report Estimates and key findings for non-compliance, tax years 2014 – 2018",b09508b0-d86b-49b9-b54d-089010896000,"Table A4: Federal tax revenue for fiscal years from 2014-15 to 2018-19, in $billions",350
+pc,4fbf08c6-a535-445e-907e-1c5ede93788a,Wetland Water Quality - Cape Breton Highlands,2d53fb7a-725a-4739-9261-4210766be598,Wetland Water Quality - Cape Breton Highlands - Data,24998
+pc,4fbf08c6-a535-445e-907e-1c5ede93788a,Wetland Water Quality - Cape Breton Highlands,fc668f37-d8ee-4167-94ef-f08870a7dcca,Wetland Water Quality - Cape Breton Highlands - Site Data,4840
+pc,4fbf08c6-a535-445e-907e-1c5ede93788a,Wetland Water Quality - Cape Breton Highlands,1d98cb4a-3179-48cc-a242-a49bc410058e,Wetland Water Quality - Cape Breton Highlands - Data Dictionary,2740
+pc,506bfc3b-18e9-4fd1-91e0-48aa9d4ba335,Water Quality - Kouchibouguac,5fd6e060-2097-4a6c-abeb-066ebb26d3c6,Water Quality - Kouchibouguac - Data,216151
+dnd-mdn,5097acea-9aa8-4f7e-82dd-873397a7ea37,National Defence Catalogue of IM/IT Services,0a33ba5c-fb21-4487-920a-8eb8d4195888,Catalogue des services de GI-TI du MDN et des FAC,108412
+pc,50d73d79-ce7d-4791-921f-b0f4b1d6f251,Tundra_Rare plants_Mingan_Abundance_Data,943ee217-6cc0-43c3-8b63-906edf1e86e2,Abundance of rare plants (colony) in the tundra- Mingan-Abundance data-1,163523
+pc,50d73d79-ce7d-4791-921f-b0f4b1d6f251,Tundra_Rare plants_Mingan_Abundance_Data,f5fe8e31-cf4b-4254-a4d5-d4c74ef884aa,Abundance of rare plants (focal) in the tundra- Mingan-Abundance data-2,101070
+pc,50d73d79-ce7d-4791-921f-b0f4b1d6f251,Tundra_Rare plants_Mingan_Abundance_Data,9db4ee2d-8209-4a97-b30b-489303ff1c91,Abundance of rare plants (colony) in the tundra- Mingan-Abundance data-1_Data_dictionary,2228
+pc,50d73d79-ce7d-4791-921f-b0f4b1d6f251,Tundra_Rare plants_Mingan_Abundance_Data,9c3edae0-f7d3-448e-9950-9fd8d35efd67,Abundance of rare plants (focal) in the tundra- Mingan-Abundance data-2_Data_dictionary,1467
+pc,513112d7-cad1-4b98-ae7f-0615fe176664,Bat NATBat Ultrasound - Jasper ,f37c25b1-6811-4674-ad78-e73dda5d9d33,Bat NATBat Ultrasound - Jasper ,4255
+pc,5154d3d0-83a0-428a-95d9-7133c7686725,Invasive Alien Plants - Mount Revelstoke,721bfa3c-3d15-4ab3-b96e-80a101ecc0c6,Invasive Alien Plants - Mount Revelstoke,24689
+pc,5154d3d0-83a0-428a-95d9-7133c7686725,Invasive Alien Plants - Mount Revelstoke,f880dc8c-16e5-4d26-a0f2-412ce29219be,Invasive Alien Plants - Mount Revelstoke - Data Dictionary,5759
+pc,51a61e6e-1ec2-463e-a87b-916370181c4d,Stream Temperature - Forillon,1e5bdbf4-a119-4616-9e7c-488695b24bd9,Stream temperature - Forillon - Data,6114597
+pc,5201abcc-4b43-4240-8104-8a709cea6116,Salmonid counting fence - Gros Morne,8002bbc0-693b-4db6-90a1-8921a978b454,Salmonid counting fence - Gros Morne - Data,189908
+pc,5201abcc-4b43-4240-8104-8a709cea6116,Salmonid counting fence - Gros Morne,13092ae1-dd22-470d-bacf-f48cf02b2ee8,Salmonid counting fence - Gros Morne - Data dictionary ,1525
+pc,522ee7d2-4cf3-4c84-a55b-b03491ad62b0,Wildlife Mortality - Glacier,20a354e9-be04-4d0b-934b-52f88e81caf9,Wildlife Mortality - Glacier,20087
+pc,522ee7d2-4cf3-4c84-a55b-b03491ad62b0,Wildlife Mortality - Glacier,64c5a6f7-d8de-41ed-a29a-0fcb0af5e4a8,Wildlife Mortality - Glacier - Data Dictionary,1167
+pc,525d64c9-0697-4b03-b670-698c9ac91434,Wetland water quality - Kejimkujik,fe8d842b-28fc-4950-b94b-21beaa9c05e7,Wetland Water Quality - Kejimkujik - Water Quality Data,21148
+cfia-acia,52ad9d5d-ade7-469e-a7e3-bef2187b0439,CFIA National Microbiological Monitoring Program Data - 2017-2018,a48df8a3-4da4-483a-bc3a-48303db1bd87,Fresh and Ready-to-Eat Fresh-Cut Fruits and Vegetables Data - 2017-2018,3817093
+esdc-edsc,52bcac7a-cb3b-4de3-8cc5-f0e6a1a0532d,Human Resources and Skills Development Canada's 2010 departmental issues survey ,11d5b6e3-c115-404a-949f-ca53c717d6d7,2009-2010 Departmental Issues Survey - DATASET,438810
+pc,52d45645-007c-4ec0-8c14-a32762e18be6,Pinnipeds - Forillon,3fe84c5f-cbed-417f-ba10-8840163ffa78,Pinnipeds - Forillon - Data - 1,783
+pc,52d45645-007c-4ec0-8c14-a32762e18be6,Pinnipeds - Forillon,e0ae5d7a-0329-4797-841a-ef1f94dc017a,Pinnipeds - Forillon - Data - 2,70594
+pc,52d45645-007c-4ec0-8c14-a32762e18be6,Pinnipeds - Forillon,603a8d98-c917-4231-a27f-59df93d170fd,Pinnipeds - Forillon - Data dictionary,407
+pch,52f06174-d7c5-4e6a-93ee-b71fa71c7915,"Percentage of Participants Who Report an Improvement in Professional Knowledge, Skills or Practices",b1c8f83b-8770-4426-802a-b8849f36639d,Heritage Workers 2017-2018_EN,2346
+pc,5306f34a-9a55-4c7e-8f3d-dc94e9e6c282,Fire Cycle-Area Burned - Grasslands,b89073a5-d3df-42eb-a278-6f20d2522a1f,Fire Cycle/Area Burned - Grasslands,3334
+pc,5306f34a-9a55-4c7e-8f3d-dc94e9e6c282,Fire Cycle-Area Burned - Grasslands,7538a5cf-3c75-4905-93a5-6c6b3ec81e3c,Fire Cycle/Area Burned - Grasslands - Data Dictionary,486
+cfia-acia,53a0fa44-b9dd-4afe-a0ef-b7076d33e939, CFIA-Undeclared Allergens and Gluten in ground Spices/Herbs - 2020-2021,79ef4366-73ab-44ac-a86e-78fb01a2229c,CFIA-Undeclared Allergens and Gluten in ground Spices/Herbs - 2020-2021,252991
+tbs-sct,53c5efa1-d398-453a-b74c-0fcc68ec5f05,Personal Record Identifier (PRI) architecture,cebd71c8-18c1-43c8-a042-05090a339412,Reference Data ,2682
+pc,540128d3-9b48-4ffe-b4fc-aabe87ee80c0,Coastal Eelgrass Spatial Extent - Terra Nova,a935c3b0-ff9d-49e4-bb6d-7ca961f3edf0,Coastal Eelgrass Spatial Extent - Dataset,41266
+pc,540128d3-9b48-4ffe-b4fc-aabe87ee80c0,Coastal Eelgrass Spatial Extent - Terra Nova,8452cdcd-4515-4de9-95c7-5fd982c44ebc,Coastal Eelgrass Spatial Extent - Data Dictionary,4474
+tbs-sct,546200d5-eeb8-40b5-a08f-6ad4824b3a56,Access to Information Modernization Action Plan Tracker,59943d52-b2bf-4a33-b460-02e5ac7ecc9e,Access to Information Modernization Action Plan Tracker,41572
+tbs-sct,546200d5-eeb8-40b5-a08f-6ad4824b3a56,Access to Information Modernization Action Plan Tracker,b018d76c-8ffa-4528-aee9-268e53674daa,Access to Information Modernization Action Plan Tracker,32421
+pc,5496f5b5-92c6-4b9a-9f9a-bb63c21c7a56,Forest Non-Native Vegetation - Yoho,fd08775d-4264-4d23-ace2-a56bfb6251a7,Forest Non-Native Vegetation - Yoho,7136
+pc,5496f5b5-92c6-4b9a-9f9a-bb63c21c7a56,Forest Non-Native Vegetation - Yoho,7036de33-4cc0-4bda-a2b2-ab950792c472,Forest Non-Native Vegetation - Yoho - data dictionary,587
+pco-bcp,5514bf8b-74ab-4779-a304-69df9e54ecda,MyDemocracy.ca Data ,7585bd73-730d-4d38-966d-736618d38301,MyDemocracy.ca – Data set,149471678
+pco-bcp,5514bf8b-74ab-4779-a304-69df9e54ecda,MyDemocracy.ca Data ,3da353e9-df46-43d4-b17c-c78d96aee863,MyDemocracy.ca – Data set,169578460
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,029d8159-3074-4637-af22-a50c7182cc51,Charities Businesses Directors/Officers,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,e62ec7b2-b40e-4d8d-954f-d2e71a71b69b,General information,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,00fddc7f-f62f-4b8d-aa35-1943433a95b9,Non-Qualified donees,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,9e979c5f-bdac-4f6d-990b-255fa533226d,Private/Public Foundations,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,38ab0eea-e36c-435e-a00e-76c5571af7eb,Activities outside Canada – Countries where program was carried,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,61265412-c557-4dce-9fa2-6806a975d809,Activities outside Canada – Details on financial,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,3800840e-ff3a-483c-8f15-e33a0b761333,Activities outside Canada - Exported goods,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,07e38548-10d2-4461-841d-5e20c28ce96b,Compensation,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,6c0b52ee-4726-48ee-b457-a5e505bfb2fb,Political Activities – Funding,
+cra-arc,5577f7aa-7a96-4c59-bc01-47ad54203930,2020 List of charities,ffa346b0-f452-42ee-abeb-31ab644edf6c,Political Activities – Resources,
+cra-arc,5584a2cf-12af-4b2d-aff5-418410cf5375,Goods and Services Tax / Harmonized Sales Tax (GST/HST) Rates from 1991 - 2016 (effective dates of rate changes),dc614072-743b-4a36-86f1-16eaf5e2dcfd,Rate Table,818
+pc,559a4bde-d336-4d8b-9361-4fbb13dd1b36,Landscape-Scale Vegetation Change - Ivvavik,857c5e49-6235-4ca1-8e9a-26cb7fea48f6,Landscape-Scale Vegetation Change - Ivvavik,1507
+tbs-sct,55aafdd7-78c4-4fc1-afd3-5611c1c33dd3,2011 Public Service Employee Survey (PSES) Results,142af1d0-a177-4b69-8686-7aae9f83363d,2011 PSES Public Service-Wide Results,33442
+pc,55c165ab-e22b-4e80-b3a1-763deb50fc1e,Status of herb willow in late snowbeds - Gros Morne,221739ea-a34d-4ca2-a8e0-53a1619f917e,Snowbed meltout phenology and status of herb willow in late snowbeds - Gros Morne,20632
+tc,56010acf-1571-4cb4-aa93-c768d4103a09,Spills Reporting at the Ottawa hangar for Aircraft Services Directorate,e0e92074-5ac4-4c3a-a259-1e0169ecd6d4,Spills Reporting at the Ottawa hangar for Aircraft Services Directorate,1886
+pc,56e53795-f70a-4216-92e8-eeaf5d7fcb79,Aquatic-Water Connectivity - Mount Revelstoke,6952f6f4-ee82-4932-9486-374bf3f6f5bb,Aquatic/Water Connectivity - Mount Revelstoke,15151
+pc,56e53795-f70a-4216-92e8-eeaf5d7fcb79,Aquatic-Water Connectivity - Mount Revelstoke,a8ac7cf9-4eab-4f9e-9ffb-c250b3d4d425,Aquatic/Water Connectivity - Mount Revelstoke - data dictionary,785
+tbs-sct,57180b36-3428-4a7f-afe3-2161a6b44ec5,Government of Canada organization name,3faaafb4-00e2-4303-947d-ac786b62559f,Concordance Data,56977
+tbs-sct,57180b36-3428-4a7f-afe3-2161a6b44ec5,Government of Canada organization name,cb5b5566-f599-4d12-abae-8279a0230928,Organization Information,74574
+pc,57c69cfc-fc85-495b-9eef-555a08404034,Parks Canada attendance 2022_23,020bfd16-2079-4fa7-839f-f4cc8c19851c,Parks Canada attendance 2022_23,5751
+pc,588a270e-843e-4558-8c81-d9029948d970,Mammal Occupancy - Kootenay,c367298e-801a-463e-b58e-9bef80595ea4,Mammal Occupancy - Kootenay,10202517
+fin,58c6095a-a967-437a-aaf3-9a0c6db874eb,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2023",3fb6eca6-4ae9-45cc-a357-a86901bee868,Data tables,78435
+fin,58c6095a-a967-437a-aaf3-9a0c6db874eb,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2023",0e1700ef-2194-46f0-8af0-c9e1db676d21,Data tables - metadata,1997
+fin,58c6095a-a967-437a-aaf3-9a0c6db874eb,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2023",c9d91c9e-a520-4b04-a2e3-2de31f6febf2,Data tables - metadata,2357
+pc,5905a98f-e934-4660-8915-1503741e5db1,Water Temperature - Prince Edward Island,8e80d665-d3ff-4e75-8779-e3a719492f5e,Water Temperature - Prince Edward Island - Données - 1,8977854
+pc,5905a98f-e934-4660-8915-1503741e5db1,Water Temperature - Prince Edward Island,91136f89-1f55-42b1-bf29-497f68f55fa9,Water Temperature - Prince Edward Island - Data - 2,13217544
+pc,599afe03-37fb-4ad9-aeaa-87dfb4ae9810,Lake Fish Health - Cape Breton Highlands,b5fd43c7-5e0f-4ab5-925c-13cd042c670f,Lake Fish Health - Cape Breton Highlands - Data - 1,2571094
+pc,599afe03-37fb-4ad9-aeaa-87dfb4ae9810,Lake Fish Health - Cape Breton Highlands,be5fd9aa-130e-436a-931b-ad0c5d0dea37,Lake Fish Health - Cape Breton Highlands - Station Data - 2,10725
+pc,599afe03-37fb-4ad9-aeaa-87dfb4ae9810,Lake Fish Health - Cape Breton Highlands,2e9c4aeb-a5ae-430c-adc8-34d80d38d85b,Lake Fish Health - Cape Breton Highlands - Data Dictionary - 3,2073
+pc,59baa0f2-cae0-4fc9-bcc4-6a8b1497f764,Mammal Occurrence - Banff,085f5a72-af09-4a09-9de1-7dc61077ee69,Mammal Occurrence - Banff,99022008
+pc,59baa0f2-cae0-4fc9-bcc4-6a8b1497f764,Mammal Occurrence - Banff,0e5358ed-2d18-4236-b321-d90b9bc49eb4,Mammal Occurrence - Banff - Data Dictionary,507
+pc,59baa0f2-cae0-4fc9-bcc4-6a8b1497f764,Mammal Occurrence - Banff,c9d11da3-8489-4091-8755-5e5fad8a6b9d,Mammal Occurrence - Banff - Camera Parameters,2057
+pc,5a017fad-5179-4830-ac73-6ad7e9216473,Area Burned Condition Class - Mount Revelstoke,473217a9-ff56-4cda-9b8a-b383f164bbe5,Area Burned Condition Class - Mount Revelstoke,12418
+pc,5a017fad-5179-4830-ac73-6ad7e9216473,Area Burned Condition Class - Mount Revelstoke,042d6f88-101a-47af-9442-4aa0a7779a20,Area Burned Condition Class - Mount Revelstoke - Data Dictionary,999
+pc,5a034977-1e2f-4669-946b-ba203eab5db5,Wetland extents - Kejimkujik,11532da6-4b92-460a-bafd-86380228bf87,Wetland Extents - Kejimkujik - Extent Data,2575
+pc,5a4e65ed-d7f0-48bc-8507-d733a62b0788,Wetland Invertebrates (Ants) - Cape Breton Highlands,9375dc19-d368-4541-97cc-d06c6efea891,Wetland Invertebrates (Ants) - Cape Breton Highlands - Data - 1,17671
+pc,5a4e65ed-d7f0-48bc-8507-d733a62b0788,Wetland Invertebrates (Ants) - Cape Breton Highlands,1330e0ae-77c6-4206-acfd-dfa6068b63bb,Wetland Invertebrates (Ants) - Cape Breton Highlands - Site Data - 2,1288
+pc,5a4e65ed-d7f0-48bc-8507-d733a62b0788,Wetland Invertebrates (Ants) - Cape Breton Highlands,8d498ee2-c849-4494-a33f-e7f5dd8c73a3,Wetland Invertebrates (Ants) - Cape Breton Highlands - Data Dictionary - 3,5640
+pc,5a53b878-5ec5-49ee-9e21-0d99a2687871,Stream Temperature - Cape Breton Highlands,d960ff35-e0cd-4f89-b1ec-dbe7a8da0b01,Stream Temperature - Cape Breton Highlands - Data - 1,4456158
+pc,5a53b878-5ec5-49ee-9e21-0d99a2687871,Stream Temperature - Cape Breton Highlands,ddf0037b-13e2-45ff-9efb-bedb77f8f5b5,Stream Temperature - Cape Breton Highlands - Data - 2,2611584
+pc,5a53b878-5ec5-49ee-9e21-0d99a2687871,Stream Temperature - Cape Breton Highlands,8dd39cf6-8052-46a7-8ef1-7184922bcb9a,Stream Temperature - Cape Breton Highlands - Data - 3,3295134
+pc,5a53b878-5ec5-49ee-9e21-0d99a2687871,Stream Temperature - Cape Breton Highlands,8ed67128-112a-434a-b30a-588fe8f6aa5e,Stream Temperature - Cape Breton Highlands - Data - 4,4286112
+pc,5a53b878-5ec5-49ee-9e21-0d99a2687871,Stream Temperature - Cape Breton Highlands,778c7d53-dbd7-4a72-92ba-f4d2a002579c,Stream Temperature - Cape Breton Highlands - Data Dictionary,3167
+pc,5a53b878-5ec5-49ee-9e21-0d99a2687871,Stream Temperature - Cape Breton Highlands,9d8539cf-3881-41a9-9757-a4c65f74761f,Stream Temperature - Cape Breton Highlands - Data - 5,3746836
+cfia-acia,5a93e43d-6eb6-445e-a913-8f484dfea33d,Food Microbiology - Targeted Surveys - 2012 - 2016 Bacterial Pathogens on Mangoes and Papayas - Final Report,f5a3e185-76ea-4692-bbf0-e71033f60d5d,Food Microbiology - Targeted Surveys - 2012 - 2016 Bacterial Pathogens on Mangoes and Papayas - Final Report,4405438
+lac-bac,5b29cbdf-2fec-40ea-bf49-3fc5c99abbd7,Calculation time to complete the evaluation of a private archive,5a3271a1-3acc-4692-b0f5-d7af6f44182f,Calculation time to complete the evaluation of a private archive,490
+pc,5b347050-568c-46db-9b6d-46c15c65d395,Plant Productivity and Growing Season Change - Sirmilik,7646bf0a-046d-4b28-a6ac-9126fbb27068,Plant Productivity and Growing Season Change - Sirmilik,1244
+pc,5b8f8447-9ebf-4101-92e6-7f584663946d,Kootenay_NP_Freshwater_Amphibian Visual Surveys,096940ef-23d7-4d39-8c29-b9da5aa5f48e,Freshwater Amphibian Occupancy - Kootenay,81157
+pc,5c43567d-a1aa-468d-8c51-6ca73d5d9132,Coastal_Tern_Mingan_Number of nest_Data,ffba279f-e0d8-441d-92aa-505371be1d44,Sterne number of nest in the coastal ecosystem- Mingan-Number of nest data,4164323
+pc,5c43567d-a1aa-468d-8c51-6ca73d5d9132,Coastal_Tern_Mingan_Number of nest_Data,1400826d-dce8-4d09-87c2-658aea1a3a8f,Sterne number of nest in the coastal ecosystem- Mingan-Number of nest data_Data_dictionary,3768
+nrcan-rncan,5c598f1f-ec76-4de4-8fe4-82e05165fc49,TOPIC Open - Literature Review Module,de87ee25-b0f2-482b-9c69-3eb8ba82063d,Trait data,857177
+nrcan-rncan,5c598f1f-ec76-4de4-8fe4-82e05165fc49,TOPIC Open - Literature Review Module,1aaad66a-3af1-4699-9523-5d7d89971016,List of scientific references used,24941
+tc,5cb32773-e7b1-4681-b82a-43cc39778c1a,Small Commercial Vessel Registry,b2075c43-6e50-40c0-a52c-e63306caa0cc,Small Commercial Vessel Registry - Dataset,6403824
+pc,5d0558d1-0ae7-4c4f-b238-01f1dcfd669e,Salmonid Distribution (Electrofishing) - Cape Breton Highlands,8513cbd4-cd22-4355-bb73-a0906bcf7723,Salmonid Distribution (Electrofishing) - Cape Breton Highlands - Data - 1,31793
+pc,5d0558d1-0ae7-4c4f-b238-01f1dcfd669e,Salmonid Distribution (Electrofishing) - Cape Breton Highlands,5c93b48f-63e2-4581-84c1-a2a4cb8b9f4a,Salmonid Distribution (Electrofishing) - Cape Breton Highlands - Site Data - 2,6342
+pc,5d0558d1-0ae7-4c4f-b238-01f1dcfd669e,Salmonid Distribution (Electrofishing) - Cape Breton Highlands,999f35b6-105e-4993-8ee0-6e548fa91d5b,Salmonid Distribution (Electrofishing) - Cape Breton Highlands - Data Dictionary - 3,1320
+csa-asc,5d31f5b8-8bd6-48fc-aad8-f4f054f83a09,Astronautics Vocabulary,9ba4c185-2aab-4cf1-ab94-2045b9da1d05,Astronautics Voabulary,153096
+pc,5d386f70-d3db-4668-9537-52f8cae9e1db,Alpine Non - Native Vegetation Kootenay ,af9e620b-99cd-4739-9505-bdc00cb98132,Alpine Non - Native Vegetation Kootenay ,3427
+pc,5d386f70-d3db-4668-9537-52f8cae9e1db,Alpine Non - Native Vegetation Kootenay ,fa9fc376-4307-4794-8403-2becfcb7bdfd,Alpine Non - Native Vegetation Kootenay - data dictionary,404
+pc,5e78402d-f053-4c5b-84ea-5224fc166e11,Grassland vegetation community areal extent and distribution - Elk Island,04190e0c-cd0e-42ce-bbc2-bc554bef34a7,Grassland vegetation community areal extent and distribution - Elk Island,707
+pc,5e78402d-f053-4c5b-84ea-5224fc166e11,Grassland vegetation community areal extent and distribution - Elk Island,227ca429-4506-4123-9ffc-137113819f9c,Grassland vegetation community areal extent and distribution - Elk Island - Data dictionary,518
+pc,5e8d13ca-2af8-4335-b770-20b898a5b530,Active Layer - Quttinirpaaq,96ac4528-5b8c-40db-a0fc-d236c2c8ddd2,Active Layer - Quttinirpaaq - Circumpolar Active Layer Monitoring Grid Data - 1,78447
+pc,5e8d13ca-2af8-4335-b770-20b898a5b530,Active Layer - Quttinirpaaq,2ad42f51-86c2-4112-8276-357b45f1d142,Active Layer - Quttinirpaaq - Thermal Characteristics of the Active Layer Data - 2,1031160
+pc,5e8d13ca-2af8-4335-b770-20b898a5b530,Active Layer - Quttinirpaaq,1eb7bb03-374a-42e4-912e-552d13f0175e,Active Layer - Quttinirpaaq - Characteristics of the Active Layer Data - 3,417
+nrcan-rncan,5f0e4a20-f6b5-4549-b34a-46cf72c103fd,TOPIC Sudbury - Leaf traits,2a57a675-f619-4420-b5a9-39d2e9deb193,Traits data,567839
+nrcan-rncan,5f0e4a20-f6b5-4549-b34a-46cf72c103fd,TOPIC Sudbury - Leaf traits,cd8627e9-df1b-41f5-bde9-626d3da85c95,Data dictionary,5170
+nrcan-rncan,5f0e4a20-f6b5-4549-b34a-46cf72c103fd,TOPIC Sudbury - Leaf traits,2e3d2dd3-f934-4c5e-aba4-11e055465359,Traits description,1537
+iaac-aeic,5f676365-2a0f-4195-b174-40b0b5156579,"Screening and Class-Screening Assessments under the Canadian Environmental Assessment Act, 1992",75a175cc-f92e-4f8f-9fbb-daa16e0499cd,Screenings and Class-Screenings Dataset,66583284
+iaac-aeic,5f676365-2a0f-4195-b174-40b0b5156579,"Screening and Class-Screening Assessments under the Canadian Environmental Assessment Act, 1992",0af3cdc1-17f2-466a-b494-66c772635aba,Data Dictionary and Field Guide,9173
+pc,5feb8e53-b747-4628-ab4f-d83aa564c194,Forest Terrestrial Birds - Glacier,4f7fa3bc-2af8-4854-b91f-38ede0a5da71,Forest Terrestrial Birds - Glacier,423768
+pc,5feb8e53-b747-4628-ab4f-d83aa564c194,Forest Terrestrial Birds - Glacier,c6e194cc-e2b7-419a-bb65-4d9bcc855190,Terrestrial Birds Data Dictionary - Glacier,1743
+pc,60562ebc-e6ae-4ab7-93d2-b406641fb74a,Forest Understory Structure - Gwaii Haanas,7210f630-0c01-4381-b082-76043924d7cc,Forest Understory Structure - Gwaii Haanas,5222
+cfia-acia,605faa48-968f-480f-ab17-e552196dd770,CFIA 2012-2014 Dioxins and Dioxin-Like Compounds in Selected Foods Data,4b5d431e-de50-4dc6-a7fd-56caf47792d6,CFIA 2012-2014 Dioxins and Dioxin-Like Compounds in Selected Foods Data,281394
+esdc-edsc,6093c709-2a0d-4c23-867e-27987a79212c,Skills and Competencies Taxonomy Data,0a120b15-9708-4d8a-8af2-2431c4540c0b,Skills and Competencies Taxonomy -EN- 2023 Version 1.0,64078
+esdc-edsc,6093c709-2a0d-4c23-867e-27987a79212c,Skills and Competencies Taxonomy Data,fb951ecd-ed5f-4d36-9a0c-07e0aad95e62,Skills and Competencies Taxonomy -FR- 2023 Version 1.0,77332
+esdc-edsc,6093c709-2a0d-4c23-867e-27987a79212c,Skills and Competencies Taxonomy Data,c8229f9c-c371-48df-98c7-dc71b9ff099f,Descriptors - Skills and Competencies Taxonomy - 2023 Version 1.0,33563
+esdc-edsc,6093c709-2a0d-4c23-867e-27987a79212c,Skills and Competencies Taxonomy Data,9fcc31ae-6522-4019-aa8b-655cfc635d12,End Notes - Skills and Competencies Taxonomy - 2023 Version 1.0,94360
+esdc-edsc,6093c709-2a0d-4c23-867e-27987a79212c,Skills and Competencies Taxonomy Data,40d3140d-1648-4d30-8dcd-05091b50112a,Sources - Skills and Competencies Taxonomy-2023 Version 1.0,9521847
+esdc-edsc,6093c709-2a0d-4c23-867e-27987a79212c,Skills and Competencies Taxonomy Data,91207fdc-fd7e-45be-b3c9-efa63c2478d2,SkillsAndCompetenciesTaxonomy-Fr-2022_Version1.0,78646
+esdc-edsc,6093c709-2a0d-4c23-867e-27987a79212c,Skills and Competencies Taxonomy Data,8a2ded9e-1738-4bf2-87f9-f3ac25e25c39,SkillsAndCompetenciesTaxonomy-2022_Version1.0_Descriptors,29119
+esdc-edsc,6093c709-2a0d-4c23-867e-27987a79212c,Skills and Competencies Taxonomy Data,276c06ff-7612-44e2-870b-190e12a1c581,SkillsAndCompetenciesTaxonomy-2022_Version1.0_EndNotes,56022
+pc,610300af-ec77-4341-8711-beec4f9d869f,Plant Health Index - Terra Nova,8611420f-bd5c-48a5-9089-cbf3f0b0e148,Plant Health Index-2,341688
+pc,610300af-ec77-4341-8711-beec4f9d869f,Plant Health Index - Terra Nova,a8332349-24cf-469c-ae33-cf3bb435a3a3,Plant Health Index - Terra Nova - Data Dictionary,5241
+tbs-sct,61417829-264b-4d75-b02e-1c88e5d33609,Language proficiency levels,31aefa9c-6e16-4759-814c-94facaaeae29,Reference Data ,2321
+tbs-sct,61417829-264b-4d75-b02e-1c88e5d33609,Language proficiency levels,875d313b-9cb8-4acf-a143-acfea60f68c5,Example Data,1484
+pc,6157a72d-a69f-45b4-b2a3-2b3ae262d0e1,Peregrine falcon nesting site occupancy-Vuntut,881ef380-9cbd-4edc-b0c3-875e98fdb867,Peregrine falcon nesting site occupancy-Vuntut,1343
+cfia-acia,61a82716-e863-4c20-b1a7-c8e05e70e72d,Children's Food Project -2017 Data,3e34dce9-2844-4cc4-8e06-05c45830509c,Children's Food Project - 2017 Data,43197262
+pc,62bb27c7-7615-400d-b865-0bcba86fa518,Decay Rates - Georgian Bay Islands,e5b836d1-ed55-4050-812b-ae86b29abf5f,Decay Rates - Georgian Bay Islands,233723
+esdc-edsc,62d50728-17bf-4bf3-9f99-fb7357ac0ee7,Canada Pension Plan Disability (CPPD) Benefit Reassessments,1b07d1e3-b085-46ea-bc3d-c4b12cfb6deb,CPPD reassessments initiated by age group,592
+esdc-edsc,62d50728-17bf-4bf3-9f99-fb7357ac0ee7,Canada Pension Plan Disability (CPPD) Benefit Reassessments,a69eadd6-535c-4fb9-8322-c5ff53f43ae0,CPPD reassessments initiated by age group,595
+esdc-edsc,62d50728-17bf-4bf3-9f99-fb7357ac0ee7,Canada Pension Plan Disability (CPPD) Benefit Reassessments,eed675b7-d37f-497d-a353-4bb6ddadb9cb,CPPD reassessments initiated by gender,226
+esdc-edsc,62d50728-17bf-4bf3-9f99-fb7357ac0ee7,Canada Pension Plan Disability (CPPD) Benefit Reassessments,19cc7c14-d1f2-4df0-9f5e-e9f8e8543736,CPPD reassessments initiated by gender,242
+esdc-edsc,62d50728-17bf-4bf3-9f99-fb7357ac0ee7,Canada Pension Plan Disability (CPPD) Benefit Reassessments,e8ac24c4-5957-4fc5-b0ce-0c529d5d71d3,CPPD reassessments initiated by province,818
+esdc-edsc,62d50728-17bf-4bf3-9f99-fb7357ac0ee7,Canada Pension Plan Disability (CPPD) Benefit Reassessments,209d22c6-179a-441a-88b1-0b41ffc4ab6a,CPPD reassessments initiated by province,828
+ssc-spc,62f76982-ee86-43f5-90d5-146d9eeeded1,Critical Incidents,63ad98ed-d163-4834-a532-29307e99da24,Critical Incidents,49802
+ssc-spc,62f76982-ee86-43f5-90d5-146d9eeeded1,Critical Incidents,2d0032c2-1791-495d-82d7-c9af2ef201d7,Critical Incidents,60912
+psc-cfp,63417e91-5c16-48ce-b326-32ad3ab86fed,Mobility Provision - Former Minister’s Staff and Excluded Positions at the Office of the Governor General’s Secretary - Summary of Requests,ef364f4e-464e-4c1e-853b-030ff3bbabd3,Mobility Provision - Former Minister’s Staff and Excluded Positions at the Office of the Governor General’s Secretary - Summary of Requests,710
+pc,636454d3-656b-45fc-89f0-1f786f798811,Terrestrial Birds - Revelstoke,3779f214-9570-458b-9b8a-8e9e399abb02,Terrestrial Birds - Revelstoke,7456
+pc,636454d3-656b-45fc-89f0-1f786f798811,Terrestrial Birds - Revelstoke,abe59ef6-3125-4d1c-8be1-00eb55dc291b,Terrestrial Birds - Revelstoke - Data Dictionary,1786
+cnsc-ccsn,642146ff-9b76-4e03-be9b-30398102445b,Regional Information and Monitoring Network,7a74d093-7bd8-4cf4-9c18-dad6c918f5c5,RIMNet - Chalk River Laboratories,1545581
+cnsc-ccsn,642146ff-9b76-4e03-be9b-30398102445b,Regional Information and Monitoring Network,81d17162-095a-4f06-bb80-78d661afb2ac,RIMNet - Nordion,24961
+cnsc-ccsn,642146ff-9b76-4e03-be9b-30398102445b,Regional Information and Monitoring Network,6dd6b69c-bac8-43bd-93c1-961c34c8802e,RIMNet - SRBT,1265685
+cnsc-ccsn,642146ff-9b76-4e03-be9b-30398102445b,Regional Information and Monitoring Network,98c3272a-7287-435c-9edd-d0b25786aac3,RIMNet - Nuclear Power Demonstration Environment,185264
+pc,64ccb967-3a50-4060-9586-9a9ca16b1693,Stream Benthic Invertebrates Richness - Thousand Islands,a5404d2a-019c-42e4-8b22-4b2978001363,Stream Benthic Invertebrates - Thousand Islands - Data,1839632
+pc,64ccb967-3a50-4060-9586-9a9ca16b1693,Stream Benthic Invertebrates Richness - Thousand Islands,c2b285f1-6279-4d1b-8ed7-1731d21b116b,Stream Benthic Invertebrates Richness - Thousand Islands - Data Dictionary,12558
+pc,64efbc67-17ea-4005-a8ad-03cccdc4b571,Seabirds - Forillon,5e479c29-c2ac-479f-90a5-6ca13d274939,Seabirds - Forillon - Data - 1,7141
+pc,64efbc67-17ea-4005-a8ad-03cccdc4b571,Seabirds - Forillon,41f5174e-f81c-4131-8be4-01ab7821018c,Seabirds - Forillon - Data - 2,2415
+pc,64efbc67-17ea-4005-a8ad-03cccdc4b571,Seabirds - Forillon,74eb51ad-4cb5-4fd5-b9fa-1bdd57de35ae,Seabirds - Forillon - Data - 3,164101
+pc,64efbc67-17ea-4005-a8ad-03cccdc4b571,Seabirds - Forillon,f2440241-4a97-4d39-b2e1-e481e464ffc0,Seabirds - Forillon - Data dictionary,773
+pc,6580aa40-4043-4938-8a42-6dd00ec22ae8,Lake water quality - Elk Island,567acfa5-9372-4a70-a9c9-98b1bf0724e5,Lake Water Quality - Elk_Island - Dataset,432194
+pc,6580aa40-4043-4938-8a42-6dd00ec22ae8,Lake water quality - Elk Island,bd286c5d-041b-4e4b-92eb-57dbc4b5a8d0,Lake Water Quality - Elk_Island - Data Dictionary,4914
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,91f2ba2c-e58d-4c30-9f17-ce1fc9f32079,Charities Businesses Directors/Officers,52153072
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,8c162df5-fe55-46ee-b662-36abaf8e459a,Financial data,18442704
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,b756a1f1-4ace-4633-86e4-147b09a0d92d,Identification,12232993
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,099e0c82-2aac-4b83-bcab-04068874a39e,Charity Contact Web Addresses,1366915
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,ec7f50d3-c564-4440-9cf5-1876944aee1a,Charitable Programs,29417449
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,5a9ce591-4be7-4616-8916-d441b1c932c0,Private/Public Foundations,3069616
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,b95d1c4a-01b7-4124-a114-35367677a3eb,Activities outside Canada – Countries where program was carried,429290
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,ae0792fb-0ead-452f-a680-9f1a2974a3d7,Activities outside Canada – Details on financial,3412195
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,b6ae3f5b-2dad-41b7-8d6c-259dadb7020d,Activities outside Canada - Exported goods,74641
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,dcaa4eaf-25d8-4047-bbf6-39f7adb77f32,Activities outside Canada - Financial resources used,418066
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,de69b9ec-b1d9-419c-8535-5072c49aa1fd,Compensation,4317808
+cra-arc,66217614-917b-4df9-a5c0-19760f318e23,2012 List of charities,ed999edc-f200-4fa0-ad00-cb8f9eff979a,Non-cash gifts (gifts in kind) received,4134931
+ssc-spc,6681cb87-ba88-45dd-809c-6fbba5f76d10,Enterprise Service Model Consumption Actuals,6e63217b-f1ad-4cd7-862e-8aee283b71c0,Enterprise Service Model Consumption Actuals FY 2022-2023,114373
+ssc-spc,6681cb87-ba88-45dd-809c-6fbba5f76d10,Enterprise Service Model Consumption Actuals,59b049b4-245b-43d7-8da4-66268c74c48a,Enterprise Service Model Consumption Actuals FY 2022-2023,114373
+pc,66c92688-4d15-4fd1-a612-97ed3130e50c,Lake Water Level - Georgian Bay Islands,80e55595-eb0e-475a-80a7-a8bbe2f4695b,Lake Water Level - Georgian Bay Islands,11591
+psc-cfp,6857a6e6-4e50-4b0e-ba8c-3ad890fa2f2a,Employment Equity Designated Groups under the Public Service Employment Act,24a44ce4-676a-45c3-9718-db34e6c07755,"Percentage of applicants to advertised processes, by Employment Equity designated group and fiscal year",5642
+psc-cfp,6857a6e6-4e50-4b0e-ba8c-3ad890fa2f2a,Employment Equity Designated Groups under the Public Service Employment Act,5dff85d4-e7af-4841-be27-f76826a5f494,"Percentage of student applicants to advertised processes and student hiring activities to the public service, by Employment Equity designated group and fiscal year",12648
+psc-cfp,6857a6e6-4e50-4b0e-ba8c-3ad890fa2f2a,Employment Equity Designated Groups under the Public Service Employment Act,e0c16e15-2f40-4129-ac35-283b3aab3c8c,"Percentage of appointments to the public service to indeterminate positions and terms of three months and over, by employment equity designated group and fiscal year",6545
+psc-cfp,6857a6e6-4e50-4b0e-ba8c-3ad890fa2f2a,Employment Equity Designated Groups under the Public Service Employment Act,ef7e5729-7a5b-40ed-baf2-0d8cadb01341,"Percentage of appointments to the public service to indeterminate positions and terms of three months and over by employment equity designated group, sex and fiscal year",11311
+psc-cfp,6857a6e6-4e50-4b0e-ba8c-3ad890fa2f2a,Employment Equity Designated Groups under the Public Service Employment Act,3bcb7687-787d-499d-b9ca-83fc9c49a6a4,Percentage of appointments to the public service to indeterminate positions and terms of three months and over by employment equity designated group and geographic area,99409
+pc,6923cb7a-9ae2-4a82-b53b-295425d089bf,Tundra - Area Burned - Prince Albert,ac9d3bd7-c3bb-4324-a638-f9930770b97a,Area Burned - Prince Albert - Data,31360
+pc,6923cb7a-9ae2-4a82-b53b-295425d089bf,Tundra - Area Burned - Prince Albert,e4346d9f-35e0-435e-8283-fafea2b63577,Area Burned - Prince Albert - Data Dictionary,879
+pc,69418113-4a33-48aa-89e4-f02f72b68276,Redback Salamander Abundance - Georgian Bay Islands,7f19afd1-06c5-4956-98a5-ef3813caf9ce,Redback Salamander Abundance,643180
+pc,69418113-4a33-48aa-89e4-f02f72b68276,Redback Salamander Abundance - Georgian Bay Islands,6adff494-835d-483f-a4ff-2fc7348e9a30,Redback Salamander Abundance - Data Dictionary,355
+pc,6a05077a-05fd-40f9-86b8-19bd0fe9f36f,Wildlife Mortality - Revelstoke,96287d19-ad26-452d-88aa-8bc8c8c6829a,Wildlife Mortality - Revelstoke,3978
+pc,6a05077a-05fd-40f9-86b8-19bd0fe9f36f,Wildlife Mortality - Revelstoke,3f17c2b7-0868-4ab5-87ac-352ae2fd3468,Wildlife Mortality - Revelstoke - Data Dictionary,1167
+rcmp-grc,6a09c998-cddb-4a22-beff-4dca67ab892f,Canadian Anti-Fraud Centre Fraud Reporting System Dataset,43c67af5-e598-4a9b-a484-fe1cb5d775b5,Canadian Anti-Fraud Centre Reporting Data,64630504
+pc,6a6e1785-2197-4fb1-96b8-2f41e89da71c,Lichens - Kejimkujik,82dc2d18-f2dc-4a1d-bd88-96b2fc61c9ff,Lichens - Kejimkujik - Species Richness Data - 1,35425
+pc,6a6e1785-2197-4fb1-96b8-2f41e89da71c,Lichens - Kejimkujik,5d7e9fa1-48a5-4b33-b85e-a4392d272fc5,Lichens - Kejimkujik - Air Purity Data - 2,9697
+pc,6a6e1785-2197-4fb1-96b8-2f41e89da71c,Lichens - Kejimkujik,23a77911-61f6-4570-8cf1-794b5058621f,Lichens - Kejimkujik - Site Information Data - 3,675
+pc,6a6e1785-2197-4fb1-96b8-2f41e89da71c,Lichens - Kejimkujik,84326af4-b86f-4bf3-bbfd-d80dba2b9a8d,Lichens - Kejimkujik - Data Dictionary - 4,1010
+pc,6aa18934-5fec-4f12-8dd7-8356555d0576,Wildlife Mortality - Banff,f4d96701-e59f-4d3d-8af0-b3b772fc68e3,Wildlife Mortality - Banff,50797
+pc,6aa18934-5fec-4f12-8dd7-8356555d0576,Wildlife Mortality - Banff,190a46d9-f5ec-4d0b-a482-f63a5c78c67f,Wildlife Mortality - Banff - Data Dictionary,1973
+aafc-aac,6adaeb1f-438b-4d74-b72b-d1b554f3a316,The AAFC Productivity Account for Canadian Agriculture,24aee03d-b0a0-435e-b67d-349a4ef3c723,PACA Prices,3585
+aafc-aac,6adaeb1f-438b-4d74-b72b-d1b554f3a316,The AAFC Productivity Account for Canadian Agriculture,6e42197a-a9d6-46f0-a48b-8b54822a4ae7,PACA Implicit Quantities,5101
+pc,6b4dce2b-50a3-401f-ac9a-ba4c13f7220f,Forest Birds - Bicknell's Thrush - Cape Breton Highlands,0fbacc31-2812-4b2b-a13e-2df7fb7021ad,Forest Birds (Bicknell's Thrush) - Cape Breton Highlands - Data,292323
+pc,6b4dce2b-50a3-401f-ac9a-ba4c13f7220f,Forest Birds - Bicknell's Thrush - Cape Breton Highlands,678ff41b-d020-4988-a232-72f16fb2bbfc,Forest Birds (Bicknell's Thrush) - Cape Breton Highlands - Data Dictionary,4007
+pc,6b710b02-3bd3-407e-b47d-24dbbbad347d,Aspen Sprout and Shrub Cover -Waterton Lakes - Conservation and Restoration Project (Fescue),13330242-a56e-4971-b629-69cef7643352,Aspen Sprout and Shrub Cover - Waterton Lakes - Burn data - 1,694
+pc,6bce7440-c5be-4e30-8ca2-1faf84a81b0d,Subtle Vegetation Change - Torngat Mountains,e5af6917-4425-43f4-a28c-b9c7db5ff3a0,Subtle Vegetation Change - Torngat Mountains,511
+pc,6bd08e02-92e1-4b54-8667-200fda0db593,Tree Health - Thousand Islands ,d91a4a06-d16c-47dc-9be5-ce6e28c4c6f2,Tree Health - Thousand Islands - Data,538046
+tbs-sct,6bed41cd-9816-4912-a2b8-b0b224909396,Government of Canada’s Greenhouse Gas Emissions Inventory,3429d4a1-6f90-4ef2-84d3-288ac91cd0e2,Item 1 - Energy Use and Greenhouse Gas Emissions Related to Federal Facilities and Fleets,216997
+tbs-sct,6bed41cd-9816-4912-a2b8-b0b224909396,Government of Canada’s Greenhouse Gas Emissions Inventory,b9474dc7-aca6-4b1f-8f35-7c03bf4ba05a,Item 1 - Energy Use and Greenhouse Gas Emissions Related to Federal Facilities and Fleets,260557
+tbs-sct,6bed41cd-9816-4912-a2b8-b0b224909396,Government of Canada’s Greenhouse Gas Emissions Inventory,a5aee6d3-4dc0-4522-9a67-cfb102da4288,Item 2 - Energy Use and Greenhouse Gas Emissions Related to Federal Facilities,546602
+tbs-sct,6bed41cd-9816-4912-a2b8-b0b224909396,Government of Canada’s Greenhouse Gas Emissions Inventory,dbd519b8-a0b7-4fb4-a926-68c08b0461ab,Item 2 - Energy Use and Greenhouse Gas Emissions Related to Federal Facilities,604267
+tbs-sct,6bed41cd-9816-4912-a2b8-b0b224909396,Government of Canada’s Greenhouse Gas Emissions Inventory,a0bb7631-6f86-4876-b3b0-330e17a51b92,Item 3 - Fuel Use and Greenhouse Gas Emissions Related to Federal Fleets,199953
+tbs-sct,6bed41cd-9816-4912-a2b8-b0b224909396,Government of Canada’s Greenhouse Gas Emissions Inventory,51e16495-9264-4b18-b7fb-c77fd1a4d8a4,Item 3 - Fuel Use and Greenhouse Gas Emissions Related to Federal Fleets,213088
+tbs-sct,6bed41cd-9816-4912-a2b8-b0b224909396,Government of Canada’s Greenhouse Gas Emissions Inventory,81d22f5b-da5c-4f1c-acbe-8cc645b2efba,Item 6 - Greenhouse Gas Emissions Related to National Safety and Security Operations,1398
+tbs-sct,6bed41cd-9816-4912-a2b8-b0b224909396,Government of Canada’s Greenhouse Gas Emissions Inventory,17e79170-2fe7-49a7-8014-ee78ec75312a,Item 6 - Greenhouse Gas Emissions Related to National Safety and Security Operations,1442
+nrcan-rncan,6c1f77a5-117b-49bf-82d7-c2c0fc020819,TOPIC CoVitas - Aboveground and belowground plant traits,b15b00e3-9a79-4030-9b63-9977f418c3b0,Data traits,1933716
+nrcan-rncan,6c1f77a5-117b-49bf-82d7-c2c0fc020819,TOPIC CoVitas - Aboveground and belowground plant traits,ede094f4-250c-46f3-a072-d215cec6f721,Data dictionary,6536
+nrcan-rncan,6c1f77a5-117b-49bf-82d7-c2c0fc020819,TOPIC CoVitas - Aboveground and belowground plant traits,9b81f96c-8b84-426d-ab63-f3dfceb0c7ef,Traits description,2343
+pc,6c644bdd-aaa2-47c5-991a-f0c42b87bccf,Wolf - Pukaskwa,493d1c60-ff79-4cbe-9f03-2ec80b05b9cb,Wolf - Pukaskwa - Effort,55815
+pc,6c644bdd-aaa2-47c5-991a-f0c42b87bccf,Wolf - Pukaskwa,fe52e8cb-2760-4d42-b221-d02d55de57b7,Wolf - Pukaskwa - Survey Data (Wildlife Camera),721208
+pc,6c644bdd-aaa2-47c5-991a-f0c42b87bccf,Wolf - Pukaskwa,db9e096b-3413-4f0c-bbc6-798e96d465bd,Wolf - Pukaskwa - Data Dictionary,2482
+pc,6c734ef3-7003-4a92-b46c-088dadde8e80,Water Quality - Banff,5ff5b695-1eea-492a-8349-74bd9991bb10,Water Quality - Banff,31296
+pc,6c734ef3-7003-4a92-b46c-088dadde8e80,Water Quality - Banff,df1d459f-df3e-48ed-9e4b-44eef1874ab4,Water Quality - Banff - Data Dictionary,2825
+pc,6ccc0dfc-df4f-4855-a6b2-b309348e351e,Key Tree Index - Prince Edward Island,516aa242-727a-4293-aa4a-4b2a60e0f72a,Key Tree Index - Prince Edward Island - 1,610832
+pc,6ccc0dfc-df4f-4855-a6b2-b309348e351e,Key Tree Index - Prince Edward Island,ee924551-b2fc-4fbd-ab31-79fac728bbd1,Key Tree Index - Prince Edward Island - Data Dictionary,2572
+pc,6d61b37e-b816-41dd-b0d0-3f5d7a95d8ec,Understory woody plant diversity - Gros Morne,c99001d3-34a3-403b-b99f-518d17590a22,Understory woody plant diversity and advanced regeneration of balsam fir - Gros Morne - Data,256658
+pc,6d61b37e-b816-41dd-b0d0-3f5d7a95d8ec,Understory woody plant diversity - Gros Morne,f6ed17ba-6090-4c30-8a22-819af6e41512,Understory woody plant diversity and advanced regeneration of balsam fir - Gros Morne - Data dictionary ,1232
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,2e434b7f-d7ad-4184-93db-ac939ee9e3b0,Refugee Protection Division Decisions 2021 Q2,105931
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,190e1cde-5b1b-4dc1-845d-9c7e260b7ab1,Refugee Protection Division Decisions 2021 Q3,99377
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,71d8e4bf-e912-4fab-ba9b-eeebed58c7b2,Refugee Protection Division Decisions 2021 Q3,100554
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,e513b95a-ade2-425a-a99e-17251abb267e,Refugee Protection Division Decisions 2021 Q4,97678
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,1a9c48cc-770d-483b-afc1-897c12db3b0d,Refugee Protection Division Decisions 2022 Q1,109208
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,08236ba0-c9c0-4eb6-b4a6-3aa0bde2d7d7,Refugee Protection Division Decisions 2022 Q2,108356
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,28f06275-498a-4cd1-a056-744efbbaabc3,Refugee Protection Division Decisions 2022 Q2,105565
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,94427c73-a563-4fb2-9fad-19d996bf330c,Refugee Protection Division Decisions 2022 Q3,134005
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,ba89655f-be19-4597-afc6-c5e82b25287d,Refugee Protection Division Decisions 2023 Q1,125371
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,b4614214-453e-48a8-8400-628d2297b474,Refugee Protection Division Decisions 2023 Q2,126293
+irb-cisr,6e47f705-71ed-41f0-8fd5-d1a8508a3b63,Refugee Protection Division (RPD) Decisions,1aea2c6f-4c4b-44e4-8ab6-524494dfd4b7,Refugee Protection Division Decisions 2023 Q3,127068
+tbs-sct,6e75f19c-d19d-48aa-984e-609c8d9bc403,Proactive Disclosure - Acts of Founded Wrongdoing,84a77a58-6bce-4bfb-ad67-bbe452523b14,Proactive Disclosure - Acts of Founded Wrongdoing,251168
+cnsc-ccsn,6ed50cd9-0d8c-471b-a5f6-26088298870e,Radionuclide Release Datasets,558315be-dd96-409e-9f36-cd6295557e5a,Radionuclide Releases - Nuclear Power Plants,123092
+cnsc-ccsn,6ed50cd9-0d8c-471b-a5f6-26088298870e,Radionuclide Release Datasets,e560cf41-afe6-47bd-ab7e-5e6f9006573a,Radionuclide Releases - Nuclear Processing Facilities,56056
+cnsc-ccsn,6ed50cd9-0d8c-471b-a5f6-26088298870e,Radionuclide Release Datasets,1f44948a-0a10-4d1e-87f1-f7fde016fef3,Radionuclide Releases - Uranium Mines and Mills,30024
+cnsc-ccsn,6ed50cd9-0d8c-471b-a5f6-26088298870e,Radionuclide Release Datasets,c215d5ba-83d0-4eee-8a47-04e62c6aea9f,Radionuclide Releases - Canadian Nuclear Laboratories,97765
+cnsc-ccsn,6ed50cd9-0d8c-471b-a5f6-26088298870e,Radionuclide Release Datasets,31a78a3a-fff9-49ca-9a1e-8b2764c34592,Radionuclide Releases - Elliot Lake,24476
+pc,6ee3a547-47a3-4cb0-bd64-f37dd1c46808,Marbled Murrelet - Gwaii Haanas,056d94c5-2f9f-4ff8-8720-52a46142572c,Marbled Murrelet - Gwaii Haanas,349
+pc,6ee442d6-96f1-41ec-a489-20eab70f489b,Waterbird status - Wood Buffalo National Park,83eacbda-b5b7-4d0b-ae25-4e6b79e547a3,Waterbird status - Wood Buffalo,412536
+pc,6ee442d6-96f1-41ec-a489-20eab70f489b,Waterbird status - Wood Buffalo National Park,2b57b4eb-a53b-4041-8683-5b077a5eb731,Waterbird status - Wood Buffalo - Data Dictionary,9114
+pc,6fb83322-8558-4f88-a438-a3d940777371,Mammal Occupancy - Yoho,7830dd46-31b9-4014-b7fd-190c172abcfd,Mammal Occupancy - Yoho,7048158
+dnd-mdn,70386a0b-21f5-4336-9362-ef1d940d94c7,Canadian Cadet Organizations- Cadet Activities,1fea9dfb-abab-4212-aab1-4dd761ca69c4,Cadet activities,186411994
+dnd-mdn,70640aa1-4dd9-40da-80b4-a2ceb6b81bcc,National Defence and the Canadian Armed Forces Audit and Evaluation Reports,624f27a9-6463-4b66-b3fa-7c7a27a87096,Audit and Evaluation Reports,19289
+pc,71a0e894-178f-45df-978b-ae6b6ed1eabd,Wolf Abundance - Riding Mountain,19956058-a078-4de5-85d7-70c7ccb69772,Wolf Abundance - Riding Mountain,2079
+pc,72530baf-5661-48bd-8b12-11321e0095f2,Wetland Water Quality - Thousand Islands,ae96a7c4-bd10-4862-ba11-7f431d2ea6f8,Wetland Water Quality - Thousand Islands - Data,63672
+pc,725d34b9-59b2-4dc8-8068-0a5a1d770380,Lake hydrology-Vuntut,62ef9257-9570-4770-a9a3-7a09340d44f1,Lake hydrology-Vuntut -Data,6829
+pc,725d34b9-59b2-4dc8-8068-0a5a1d770380,Lake hydrology-Vuntut,994f4ce9-6759-47eb-be6f-c391a0e2a570,Lake hydrology-Vuntut -Data Dictionary,603
+cfia-acia,7296b53e-56fc-41df-82c6-04656422b39e,"Ochratoxin A in Wheat Products, Oat Products, Rice Products and Other Grain Products - April 1, 2018 to March 31, 2019",d9d79110-e472-4aec-89ee-e51861f4d88d,"Ochratoxin A in Wheat Products, Oat Products, Rice Products and Other Grain Products - April 1, 2018 to March 31, 2019",139876
+pc,72b163e6-d881-4c7a-85e4-cc111a38de97,Forest Health Index - Cape Breton Highlands,43a1446a-8bc7-4de4-a024-0ca32483d99e,Forest Health Index - Cape Breton Highlands - Regeneration Data - 1,11523
+pc,72b163e6-d881-4c7a-85e4-cc111a38de97,Forest Health Index - Cape Breton Highlands,77efbc25-ba53-41bc-9a7e-ece6eba1c7a8,Forest Health Index - Cape Breton Highlands - Tree Core Data - 2,7189
+pc,72b163e6-d881-4c7a-85e4-cc111a38de97,Forest Health Index - Cape Breton Highlands,9475ddf4-bb53-4958-b654-dfbe36dd00f4,Forest Health Index - Cape Breton Highlands - Tree Health Data - 3,33249
+pc,72b163e6-d881-4c7a-85e4-cc111a38de97,Forest Health Index - Cape Breton Highlands,5bde01de-f892-4590-9630-bff3e7d6ba84,Forest Health Index - Cape Breton Highlands - Disturbance Data - 4,989
+pc,72b163e6-d881-4c7a-85e4-cc111a38de97,Forest Health Index - Cape Breton Highlands,e3fe454f-8034-4c54-a835-2929c1e96971,Forest Health Index - Cape Breton Highlands - Site Data,1225
+pc,72b163e6-d881-4c7a-85e4-cc111a38de97,Forest Health Index - Cape Breton Highlands,bd55798d-60b0-464d-8a98-06b78e2cb0ee,Forest Health Index - Cape Breton Highlands - Data Dictionary,11053
+cfia-acia,7320b4ee-39d1-4bc2-a7fe-74259ec162d1,Oils Authenticity Summary Data ,d768b3b1-cb00-4eb5-82d8-efc01cfd3335,Olive Oil Authenticity Summary Data - 2020-2021,5295
+cfia-acia,7320b4ee-39d1-4bc2-a7fe-74259ec162d1,Oils Authenticity Summary Data ,7a14ac0c-5494-4825-8da3-b62f1c09c117,Expensive Oil Authenticity Summary Data - 2020-2021,5659
+dfatd-maecd,732e592c-e38f-469e-be9e-cd86bb843187,Handbook of Export and Import Commodity Codes - 2012,d2866110-3e29-4037-a8a6-1098c1834da2,Handbook of Export and Import Commodity Codes - 2012,109592
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,f3950e0b-2645-4337-b57a-8a1f1e7c12e5,Charities Businesses Directors/Officers,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,3a9c8481-b3f9-42b8-8f68-79d995308031,Financial data,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,448f042e-6b78-48d5-86dc-af4d8c6cb64c,General information ,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,3dc735a4-7686-4905-9f2e-f7391e745c6b,Non-Qualified donees,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,93935786-6894-4278-bf27-392285b52734,Private/Public Foundations,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,ed31b022-2b14-4368-949e-f7ea85767d07,Activities outside Canada – Countries where program was carried,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,569846ec-dee1-4bfc-9594-e056dbdde6c8,Activities outside Canada – Details on financial,1396090
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,f7ec2a58-0716-44dd-8f58-81664bf33834,Activities outside Canada - Exported goods,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,63a6033e-9d52-4000-bff5-c8be69f3075c,Compensation,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,3f91c348-573f-421c-82b6-d32fe7fef2dc,Non-cash gifts (gifts in kind) received,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,28f16a6a-13a5-49c2-b93b-81845c5c4650,Political Activities – Funding,
+cra-arc,73602f89-08fc-435b-880b-691bfbe96123,2015 List of charities,162d7a58-7c73-476f-a80b-17643e6dec3c,Political Activities – Resources,
+hc-sc,736fa9b2-62e4-4e31-aea4-51869605b363,CPADS 2021-2022 PUMF Data,d2639429-c304-45a6-90b3-770562f4d46d,CPADS 2021-2022 PUMF,40924860
+pc,741f9aee-555d-4ec1-a8fe-3a550a9d5ecf,Native Amphibians - Pacific Rim,17b073d4-ed5d-4350-baea-370968329320,Native Amphibians - Pacific Rim - Data,5462
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,278d8173-8c2d-4366-afc2-0b3626e7ec8a,Human-wildlife coexistence data dictionary - Parks Canada,159828
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,7f1ce4da-f174-4394-a53d-398b30c0f69d,Human-wildlife coexistence header descriptions - Parks Canada,5583
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,eaadb900-e1e5-4844-9617-4b8d76f0ea80,Human-wildlife coexistence incidents detailed records - Parks Canada,16452619
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,90f1da65-3722-4a14-98c9-a2f6a886b1a1,Human-wildlife coexistence incidents detailed records - Parks Canada,15116480
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,d6892a77-5e2f-407e-80ee-3b76466a4d80,Human-wildlife coexistence animals involved detailed records - Parks Canada,17961432
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,85fc4af1-e2da-4621-b6b4-4cb5080a3b89,Human-wildlife coexistence animals involved detailed records - Parks Canada,19892932
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,59dca4f9-9d24-47fe-bbe5-f1b350681bf4,Human-wildlife coexistence responses detailed records - Parks Canada,12245271
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,4560df90-7a4a-4e62-9e60-fe221af3de9c,Human-wildlife coexistence responses detailed records - Parks Canada,14147984
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,da28a47e-ae5e-4d97-92ec-b9a2a99067aa,Human-wildlife coexistence activities detailed records - Parks Canada,9312441
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,819282dd-1ebe-47cc-8330-c8fe012dffc9,Human-wildlife coexistence activities detailed records - Parks Canada,10405089
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,ca8e6a88-3aa6-44a4-a2b8-5b24f33ad9b4,Human-wildlife coexistence animals killed summary - Parks Canada - number of animals killed by human causes,16560
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,7ecebfbd-b1d9-421c-929c-19dbd09f0b22,Human-wildlife coexistence animals killed summary - Parks Canada - number of animals killed by human causes,19546
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,18b48f36-0973-4c9e-bb02-e9b109b1bf5e,Human-wildlife coexistence animals killed by collisions summary - Parks Canada - number of animals killed by collisions with vehicles and trains,32374
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,e9276486-8ec3-49f1-8bbe-11dbdbdbcae4,Human-wildlife coexistence animals killed by collisions summary - Parks Canada - number of animals killed by collisions with vehicles and trains,35859
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,72b501f4-bf39-4254-9a19-8cce0b4fdd80,Human-wildlife coexistence animals killed by collisions summary - Parks Canada - number of animals killed by collisions with vehicles and trains by site,43645
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,6a22649b-0ee0-46a4-bd3e-1196f30a5d82,Human-wildlife coexistence animals killed by collisions summary - Parks Canada - number of animals killed by collisions with vehicles and trains by site,46810
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,10af367c-0504-42cf-bfa8-8c3baf0f2c30,Human-wildlife coexistence aggressive encounters summary - Parks Canada - number of aggressive encounters by species,12666
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,75cd4a59-64e9-43dd-af88-d3ac730dfa36,Human-wildlife coexistence aggressive encounters summary - Parks Canada - number of aggressive encounters by species,14449
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,d22df09e-bcea-4d78-81d9-416d93a21930,Human-wildlife coexistence aggressive encounters summary - Parks Canada - number of aggressive encounters by species and by site,54509
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,b64a581a-5d6e-4b57-aecd-d325d697c84c,Human-wildlife coexistence aggressive encounters summary - Parks Canada - number of aggressive encounters by species and by site,60046
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,14c31f6a-6c48-47a7-88ac-6bf5f71849f5,Human-wildlife coexistence incidents summary - Parks Canada - number of incidents by incident type,6629
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,1ec6f256-4045-47f1-a887-5a4e5a54881c,Human-wildlife coexistence incidents summary - Parks Canada - number of incidents by incident type,7309
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,cea1c483-f62c-4e1a-babf-83714a4b785d,Human-wildlife coexistence incidents summary - Parks Canada - number of incidents by site,7407
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,7612325f-c5c4-434a-9bbb-9237f8d283c4,Human-wildlife coexistence incidents summary - Parks Canada - number of incidents by site,8644
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,76552794-ceef-4179-9856-631adcfd8078,Human-wildlife coexistence incidents time summary - Parks Canada - hours of staff time by incident type,12289
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,671bc763-324e-4a56-a80b-0d39335f3114,Human-wildlife coexistence incidents time summary - Parks Canada - hours of staff time by incident type,12047
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,8251f891-a9a5-45b4-b77d-56d2773c8385,Human-wildlife coexistence incidents time summary - Parks Canada - hours of staff time by site,9413
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,789764b0-da6d-44fc-b675-5b6902987ce3,Human-wildlife coexistence incidents time summary - Parks Canada - hours of staff time by site,10361
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,6b12979e-29b0-42fc-babd-d26935b4f0e8,Human-wildlife coexistence animals involved summary - Parks Canada - number of incidents by species,14109
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,be457295-fb88-4723-8f20-0e94a7188522,Human-wildlife coexistence animals involved summary - Parks Canada - number of incidents by species,15061
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,ad0d911c-7831-4c9b-b862-93236e88ce37,Human-wildlife coexistence animals involved time summary - Parks Canada - hours of staff time by species,22142
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,4c791c6a-512c-4166-9893-b7e57ddd766c,Human-wildlife coexistence animals involved time summary - Parks Canada - hours of staff time by species,21576
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,22590684-9f22-44ab-9493-a86064f4ba62,Human-wildlife coexistence responses summary - Parks Canada - number of incidents by response type,160554
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,3d58ee7f-8607-4351-a8fe-cff2eba73fec,Human-wildlife coexistence responses summary - Parks Canada - number of incidents by response type,197965
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,4cbdffd2-d2aa-4242-86f3-156304dbabbe,Human-wildlife coexistence unnatural attractants summary - Parks Canada - number of animals involved with unnatural attractants,10352
+pc,743a0b4a-9e33-4b12-981a-9f9fd3dd1680,Human-wildlife coexistence incidents managed by Parks Canada,428d66b9-b9f8-4efb-854a-f75b8068ca72,Human-wildlife coexistence unnatural attractants summary - Parks Canada - number of animals involved with unnatural attractants,11712
+wd-deo,748e3dbb-9ad2-4dc7-bfae-225c0e62fc28,Value of exports of goods from western Canada (in dollars),c1a9658f-8f1c-43d5-97f2-ddf08a065094,Exports_e.csv,139
+csec-cstc,74ca048c-0ac9-4400-8e6c-82dee15f469f,Contracting overview,e368f7f9-7b76-40db-94e9-39e23c1e8319,CSV EN,691
+csec-cstc,74ca048c-0ac9-4400-8e6c-82dee15f469f,Contracting overview,25f0208f-016d-4d38-8331-1d4593367e19,CSV FR,755
+esdc-edsc,754e11cc-3e75-4148-816d-2509470a0f4f,Old Age Security (OAS) and Guaranteed Income Supplement (GIS) - Benefits by Age Group 65-74 and 75+,6fd47809-9f84-4a53-876a-23f41515068c,OAS benefits by age group 65-74 and 75+,62054
+esdc-edsc,754e11cc-3e75-4148-816d-2509470a0f4f,Old Age Security (OAS) and Guaranteed Income Supplement (GIS) - Benefits by Age Group 65-74 and 75+,bded1d58-777b-49f1-ba75-6e2ca85b9efb,GIS benefits by age group 65-74 and 75+,60972
+lac-bac,7642381d-8008-40a4-82f4-9a71bea3ae6b,Cost per attendant at events on managing government information,0adb0630-a93f-4be6-bcd9-98fd8f4ce860,Cost per attendant at events on managing government information,271
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,34b83fc9-03eb-45d1-9ba5-58d77435cdd4,Charities Businesses Directors/Officers,54474144
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,898dd1de-9d8b-4605-857f-d82cce4c5b21,Financial data,18967242
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,08e0fcd5-0e7e-48eb-98a1-48db5b6d7cf7,Identification,12133343
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,d3fc45d1-5846-41c6-8a1a-fc92a9a463dc,Charitable Programs,29565219
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,b2c46be3-404c-42ab-883b-f716eac3163d,Private/Public Foundations,3068910
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,dc1e6f19-9be5-4906-8612-2e92641b758b,Activities outside Canada – Details on financial,3395951
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,cdb46920-4183-4649-bb6b-d93ffc5fc001,Activities outside Canada - Exported goods,73326
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,4b2cbe49-c121-4ac8-ba15-52f035e7591e,Activities outside Canada - Financial resources used,364365
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,48df6451-bddc-4a9f-93dc-94e17117a230,Compensation,4275846
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,24b15665-cc08-4940-91be-6c6476ddfa48,Non-cash gifts (gifts in kind) received,4093359
+cra-arc,76564bbf-4391-488a-8ea2-fe5025ee7f2d,2010 List of charities,4f797fec-137f-448b-bac4-38224687083d,Charity Contact Web Addresses,1333503
+pc,76d76bfd-3b16-4c96-b802-db64cf598b8b,Piping Plover - Kouchibouguac,3de4ff5a-de62-4e3e-8eb4-ea1d845e8a60,Piping Plover - Kouchibouguac - Metadata,802
+pc,76fe4403-12f0-4699-934d-ec04103b70bc,Bison Abundance - Grasslands,d00e4e79-1be4-419c-921a-acdbdf8ab9f4,Bison Abundance - Grasslands,453
+pc,77997b3f-f69d-43fa-9c86-f5ed9155f404,Invasive Alien Plants - Glacier,0ab9eca7-bf87-4807-bd15-0e96573879e8,Invasive Alien Plants - Glacier,38538
+pc,77997b3f-f69d-43fa-9c86-f5ed9155f404,Invasive Alien Plants - Glacier,6167406a-7888-4e2f-ac0b-d0ca920dc3b3,Invasive Alien Plants - Glacier - Data Dictionary,5759
+pc,77a29819-7d65-4db2-849e-b121622a237f,Tundra vegetation climate - Torngat Mountains,ec68e221-0348-4b93-b054-b30f6eaad33d,Tundra vegetation climate - Torngat Mountains -  Air data,22264561
+pc,77a29819-7d65-4db2-849e-b121622a237f,Tundra vegetation climate - Torngat Mountains,b5e1d840-0ebe-4c90-a8ab-4c722d3a552d,Tundra vegetation climate -  Torngat Mountains - Soil data,18310659
+pc,77cfcefd-2a24-4a1f-a90b-eb65e0cb8fb9,Dall's Sheep Survey Count - Kluane,12f7ba8a-a8f4-4034-9692-d2209d56a8d6,Dall's Sheep Survey Count - Kluane,4115
+phac-aspc,787e3643-ea0b-4062-bcee-01c048735ec0,The Public Health Agency of Canada Biosafety and biosecurity inspection summaries for organizations working with human pathogens and toxins,da77b3af-eb3f-4894-86bd-eeefa58254ad,Inspection Summaries 2022-2023,70605
+phac-aspc,787e3643-ea0b-4062-bcee-01c048735ec0,The Public Health Agency of Canada Biosafety and biosecurity inspection summaries for organizations working with human pathogens and toxins,1c55def7-c052-45d2-86d4-c1ee140f3f03,Inspection Summaries 2022-2023,79735
+phac-aspc,787e3643-ea0b-4062-bcee-01c048735ec0,The Public Health Agency of Canada Biosafety and biosecurity inspection summaries for organizations working with human pathogens and toxins,e71f81b6-c5ea-47ec-b2e0-9ad975a37f27,Inspection Summaries 2023-2024,82188
+phac-aspc,787e3643-ea0b-4062-bcee-01c048735ec0,The Public Health Agency of Canada Biosafety and biosecurity inspection summaries for organizations working with human pathogens and toxins,2b38d736-42f1-483b-8bdf-b983eca90c38,Inspection Summaries 2023-2024,92698
+phac-aspc,787e3643-ea0b-4062-bcee-01c048735ec0,The Public Health Agency of Canada Biosafety and biosecurity inspection summaries for organizations working with human pathogens and toxins,7135fdb0-6d3d-41a6-bced-e492f5757d22,Inspection Summaries Q1 2024-2025,29798
+phac-aspc,787e3643-ea0b-4062-bcee-01c048735ec0,The Public Health Agency of Canada Biosafety and biosecurity inspection summaries for organizations working with human pathogens and toxins,e16dc889-73fb-4e2e-a03f-827bc51e2d6f,Inspection Summaries Q1 2024-2025,33317
+phac-aspc,787e3643-ea0b-4062-bcee-01c048735ec0,The Public Health Agency of Canada Biosafety and biosecurity inspection summaries for organizations working with human pathogens and toxins,9d16deab-36c3-407c-8a6a-1e65ab865f4a,Inspection Summaries Q2 2024-225,
+phac-aspc,787e3643-ea0b-4062-bcee-01c048735ec0,The Public Health Agency of Canada Biosafety and biosecurity inspection summaries for organizations working with human pathogens and toxins,88464c61-0180-4104-bab9-cf7381990363,Inspection Summaries Q2 2024-225,
+dnd-mdn,79ec0e13-2a2c-44a2-9723-bf9c706a72ff, National Defence Civilians' Workplace representation,0f886831-96fc-4f9d-8d52-3dc25becc010,National Defence Civilians' Workplace representation,1639
+pc,7a496fbd-7bd0-48d0-80e5-8b13752e1814,Lake Fish Index - Kootenay,180caa0d-eb13-41ad-8913-b28e7e6bdbda,Lake Fish Index - Kootenay,776
+pc,7a496fbd-7bd0-48d0-80e5-8b13752e1814,Lake Fish Index - Kootenay,ae8db9f3-3b22-4c77-964f-b6d529f47675,Lake Fish Index - Kootenay - data dictionary,2866
+pc,7a9190d4-baa3-4b71-aba6-a085055d8e9e,Forest Vegetation - Nahanni,01e5cef8-f486-4c40-a070-b8be240f9fd4,Forest Vegetation - Nahanni  - Data - 1,50550
+pc,7a9190d4-baa3-4b71-aba6-a085055d8e9e,Forest Vegetation - Nahanni,24d68c87-972a-49ac-ab04-c5fa72306691,Forest Vegetation - Nahanni  - Data - 2,16366
+pc,7a9190d4-baa3-4b71-aba6-a085055d8e9e,Forest Vegetation - Nahanni,0e0f1025-d6d0-4436-9eb9-b57885f55340,Forest Vegetation - Nahanni  - Data - 3,6108
+pc,7a9190d4-baa3-4b71-aba6-a085055d8e9e,Forest Vegetation - Nahanni,b1c685fd-aa48-4c37-bbf0-d575a2d5da5c,Forest Vegetation - Nahanni - Data dictionary,7316
+pc,7bab74f4-52a5-434d-a4f0-279bed437120,Blister Rust - Yoho,7a3fff19-49e4-4ebe-8a71-f697fd7cd520,Blister Rust - Yoho,3806
+pc,7bab74f4-52a5-434d-a4f0-279bed437120,Blister Rust - Yoho,5e984c05-8046-46f0-b150-10f687470489,Blister Rust - Yoho - data dictionary,763
+pco-bcp,7c03f039-3753-4093-af60-74b0f7b2385d,Government of Canada - Consultations,92bec4b7-6feb-4215-a5f7-61da342b2354,Consultations - All ,6074950
+cfia-acia,7c2ec6ef-48de-4594-8c6a-b2fc2a5803ff,CFIA Mercury and Metals in Fish Products - 2000-2021,56150107-d756-4ce2-a295-f8da6134e673,CFIA Mercury and Metals in Fish Products - 2000-2021,18238981
+pc,7c3a6db2-cd73-4a53-9313-038f6409d3be,Kelp Fish Community - Pacific Rim,6440de32-9292-4d75-b7ad-37b872c6c23e,Kelp Fish Community - Pacific Rim - Data,46546
+pc,7c3a6db2-cd73-4a53-9313-038f6409d3be,Kelp Fish Community - Pacific Rim,44037b91-015a-4ece-8f90-da997a7403db,Kelp Fish Community - Pacific Rim - Data Dictionary,3808
+pc,7c566f33-e8e7-4fd1-b466-8fe43030fe59,Water Quality - Waterton Lakes - Freshwater,5d9f9519-2cae-4a14-b1cc-f143b9cd8d14,Water Quality Index - Waterton Lakes - WQI value data - 1,1142
+pc,7c566f33-e8e7-4fd1-b466-8fe43030fe59,Water Quality - Waterton Lakes - Freshwater,e900d85a-3bba-4f8c-9bb2-e3b950c763c9,Water Quality Index - Waterton Lakes - WQI value data dictionary - 2,383
+pc,7ccf75e5-56d4-4b3a-a4a3-9ac1c2af7c13,Common loons - Kejimkujik,e8139441-cf25-4f9c-9e81-4d101858076c,Common Loons - Kejimkujik - Population Survey Data,37982
+pc,7d68ea12-dd83-46dc-a5b0-d5f96450f898,Muskrat Aerial Survey - Wood Buffalo National Park,3a2c1ce7-d463-4987-92b8-ee0e2aa6a21b,Muskrat Aerial Survey - Wood Buffalo,37043
+pc,7d68ea12-dd83-46dc-a5b0-d5f96450f898,Muskrat Aerial Survey - Wood Buffalo National Park,472ca94c-fa8e-4d48-b98a-0cad67fdfa0a,Muskrat Aerial Survey - Wood Buffalo - Data Dictionary,352
+pc,7da52c0f-e1bb-4307-af60-f146c2f572c4,Hydrological Quality Index - Cape Breton Highlands,ee7e07ff-d856-4f5d-9ea6-cabc0cefcfbc,Hydrological Quality Index - Cape Breton Highlands - Data,470797
+cra-arc,7da75a41-20da-43c9-9e9b-66b62a9ca813,Statistics on the one-time emergency payment increase to the Canada Child Benefit (CCB),3e8ea93a-b8e2-450c-aafa-d80982f9a9a8,Explanatory Notes,1054
+cfia-acia,7ecfee4c-b6f5-45f8-9fd4-16976f55f8d9,Honey Authenticity Summary Data,20322f50-ae97-4c5d-827c-807dd4e1b7d2,Honey Authenticity Summary Data - 2022-2023,9151
+cfia-acia,7ecfee4c-b6f5-45f8-9fd4-16976f55f8d9,Honey Authenticity Summary Data,1e5270ee-5bb4-43b0-8c1a-edfb336ae7a4,"Honey Authenticity Summary Data – CFIA Inspector Targeted, 2019-2020",13242
+cfia-acia,7ecfee4c-b6f5-45f8-9fd4-16976f55f8d9,Honey Authenticity Summary Data,b7ad549c-2ea1-4ae3-98b2-a2b469f6f73f,"Honey Authenticity Summary Data – Marketplace, 2019-2020",15521
+cfia-acia,7ecfee4c-b6f5-45f8-9fd4-16976f55f8d9,Honey Authenticity Summary Data,d8a2af6b-5200-4c57-b71d-a1aa818b3759,Honey Authenticity Summary Data - 2018-2019,23892
+pc,7ed71bc4-e91d-4b04-ac2c-220294954cfb,Area disturbed by Fire - Waterton Lakes - Forest,7ebb980c-ba84-4ca9-a595-808df172f7de,Area Distrubed by Fire - Waterton Lakes - Forest data - 1,3099
+pc,7ed71bc4-e91d-4b04-ac2c-220294954cfb,Area disturbed by Fire - Waterton Lakes - Forest,4c6356de-4f38-44b9-98ec-2ed2edf7d3c8,Area Distrubed by Fire - Waterton Lakes - Forest data dictionary - 2,1222
+pc,7f396526-e579-4a72-aed2-1f20f5e10cbe,Alpine Non - Native Vegetation - Yoho ,e4360577-022d-4ad5-b85e-520df1f0065f,Alpine Non - Native Vegetation Yoho ,2633
+pc,7f396526-e579-4a72-aed2-1f20f5e10cbe,Alpine Non - Native Vegetation - Yoho ,aa4ef0d2-66fd-493d-9e08-d1715cdc6661,Alpine Non - Native Vegetation Yoho - data dictionary,404
+psc-cfp,7f459f0c-979f-4d2f-b22b-8484571dc543,Applications to the Public Service,4c671093-a56e-44cc-b042-75909d7c6fa5,Applicants by recruitment program and geographic area of residence,94842
+psc-cfp,7f459f0c-979f-4d2f-b22b-8484571dc543,Applications to the Public Service,15e71e3e-ee25-4391-b42a-294b64d8f929,"Applicants by recruitment program and geographic area of residence for Ontario, National Capital Region and Quebec",22549
+psc-cfp,7f459f0c-979f-4d2f-b22b-8484571dc543,Applications to the Public Service,7893faec-c18c-4091-ba98-2d7c1552bc16,Applicants to external advertisements,30525
+ssc-spc,7f601545-fc5e-4937-af3e-fc856646c6c3,SSC-Consumer -led Project Statistics,2a3d2f6e-4041-4b9b-b878-61ce338c979d,"Percentage of SSC-led projects rated as on time, on scope and on budget",5488
+ssc-spc,7f601545-fc5e-4937-af3e-fc856646c6c3,SSC-Consumer -led Project Statistics,819c1ca8-2536-40be-8c58-f1e828d34834,"Percentage of SSC-led projects rated as on time, on scope and on budget ",5540
+cfia-acia,7f62f271-e392-4ca5-a957-49e590b3768d,"2009-2010 Melamine Residues In Fluid Milk, Milk-Based Products and Soy-Based Products",27541aaa-a3c8-4081-bdc4-e31c5b085ff2,"2009-2010 Melamine Residues In Fluid Milk, Milk-Based Products and Soy-Based Products",73833
+pc,7fbb7a4a-cf3d-4874-9a8f-951983f2d9db,Whitebark Pine Seed data - Glacier,7dab49cb-40a8-4393-9fd3-3ce071558a20,Whitebark Pine Seed data - Glacier,1402
+pc,801ad417-f06e-49e1-8bac-27744e8a4bea,Water Quality - Gwaii Haanas,8d86ecd4-5c16-4994-8d74-ccf5aa902443,Water Quality - Gwaii Haanas,14717
+pc,801ad417-f06e-49e1-8bac-27744e8a4bea,Water Quality - Gwaii Haanas,b4c5c5df-b9e9-4afc-ae41-c22303aa000d,Water Quality - Gwaii Haanas - data dictionary,344
+pc,802cd701-3213-4010-939a-4ef1e957fe4b,Five-lined Skink - Point Pelee,51677e91-70f8-4d26-b647-fde80a31ed9d,Five-lined Skink - Point Pelee - Monitoring Data - 1,149463
+pc,802cd701-3213-4010-939a-4ef1e957fe4b,Five-lined Skink - Point Pelee,2aaae2fd-2c6a-4353-8532-75d3bcbb1c95,Five-lined Skink - Point Pelee - Monitoring Data - 2,41960
+pc,802cd701-3213-4010-939a-4ef1e957fe4b,Five-lined Skink - Point Pelee,667813d6-3732-4a9a-9a3f-6640a5e7a970,Five-lined Skink - Point Pelee - Monitoring Data Dictionary,1070
+pc,80302ae9-a331-45cb-af8d-edb44cb51981,Stream thermal regime - Gros Morne,ce744457-bb42-4721-8a8e-2d693466e517,Stream thermal regime and hydrology - Gros Morne,26326979
+wd-deo,80465a11-b974-45a5-a99a-a24a6cad078b,Amount leveraged per dollar by WD in community projects,1bbd6b02-4a10-4937-93a2-7f6c5d9e092f,Leverage_e.csv,240
+lac-bac,805cafc6-3e3f-4edb-80cd-0dc2584d940b,At-risk audio-visual material migrated from an obsolete to a current digital file format,2391db83-21b6-45af-80b4-a1c8cdf0b457,At-risk audio-visual material migrated from an obsolete to a current digital file format,356
+tbs-sct,80ae9905-9034-4cf7-9057-d34af6065561,GC InfoBase - COVID-19 Estimates Initiatives (2020-21),b8a6cd7a-a290-4e04-aa5a-926a9e909fb2,Authorities by initiative,62717
+tbs-sct,80ae9905-9034-4cf7-9057-d34af6065561,GC InfoBase - COVID-19 Estimates Initiatives (2020-21),4e14ada2-4765-467d-8f34-f60bb2bd966c,Authorities by initiative,76739
+hc-sc,80f802ea-b502-4e51-b9a1-d7cd67f95ad5,Tiletamine-Zolazepam use in wildlife immobilization  (2012-2022),c14cf9ed-9150-4b0c-94df-c8ee9282a8d8,Tiletamine-zolazepam Wildlife Immobilization - EDR and ESC follow-ups,91410
+hc-sc,80f802ea-b502-4e51-b9a1-d7cd67f95ad5,Tiletamine-Zolazepam use in wildlife immobilization  (2012-2022),970a8088-3aae-4859-bb8b-d9b3aa9c4e81,Tiletamine-zolazepam Wildlife Immobilization - EDR and ESC follow-ups,94340
+pc,8175ae62-0eb7-485d-abc4-8a464a8ce5cf,Wetland Productivity - Prince Edward Island,de4bdd90-5cab-447d-99cf-f6b848cb0fa2,Wetland Productivity - Prince Edward Island - 1,1007
+pc,8175ae62-0eb7-485d-abc4-8a464a8ce5cf,Wetland Productivity - Prince Edward Island,ff7b310e-431b-4564-b08a-0477333a95cf,Wetland Productivity - Prince Edward Island - Data Dictionary - 2,318
+pc,82179921-2570-4fcf-8f31-246e213573c3,Lake Fish Index - Banff,ed9b3971-3384-4464-8a06-102f72d22501,Lake Fish Index - Banff,8876
+pc,82179921-2570-4fcf-8f31-246e213573c3,Lake Fish Index - Banff,e903b382-b5d2-45b3-a496-ea184f4eda1c,Lake Fish Index - Banff - Data Dictionary,3214
+pc,823ce7b5-fc0b-4948-9935-3ade45b55bbf,Area Disturbed by Fire - Banff,a54d849f-e1af-4144-98a5-bcd7134d4ed3,Area Disturbed by Fire - Banff,18156
+pc,823ce7b5-fc0b-4948-9935-3ade45b55bbf,Area Disturbed by Fire - Banff,9471fee8-ad7b-4515-be5d-93917dae9a72,Area Disturbed by Fire - Banff - Data Dictionary,859
+pc,82617501-ffcd-49a6-a1d2-8a3ef91286fe,Eastern Prickly Pear Cactus - Point Pelee,0940add0-00d3-4011-b107-97bc5ed31126,Eastern Prickly Pear Cactus - Point Pelee - Monitoring Data,59151
+pc,82617501-ffcd-49a6-a1d2-8a3ef91286fe,Eastern Prickly Pear Cactus - Point Pelee,cffde3b0-cead-4879-b530-c90fcd57f79f,Eastern Prickly Pear Cactus - Point Pelee - Monitoring Data Dictionary,485
+pc,82c2a1e5-dda5-4e31-afc4-dfac2a6f6279,Advanced regeneration of balsam fir - Gros Morne,b8de8f8a-628f-4375-81b7-7a0d16ce4371,Understory woody plant diversity and advanced regeneration of balsam fir - Gros Morne - Data,256658
+pc,82c2a1e5-dda5-4e31-afc4-dfac2a6f6279,Advanced regeneration of balsam fir - Gros Morne,99c580b9-f3de-4c47-b043-fb1be7f3823c,Understory woody plant diversity and advanced regeneration of balsam fir - Gros Morne - Data dictionary ,1232
+pc,82e66a83-ff76-4bce-95b1-c7355a147c52,Aquatic Connectivity - Jasper,65a94f2b-2ed0-4070-bcb0-ffd1f96f23a6,Aquatic Connectivity - Jasper,7895
+pc,82e66a83-ff76-4bce-95b1-c7355a147c52,Aquatic Connectivity - Jasper,6dc2f263-7ea9-4365-ab51-bfa0f3855f21,Aquatic Connectivity - Jasper - Data Dictionary,335
+pc,82f02c1a-6f9d-4441-b2df-7bb59f9e84a2,Black-Tailed Prairie Dog Area of Occurrence - Grasslands,d0603aa3-6410-4924-a144-7cc0ec32865e,Black-Tailed Prairie Dog Area of Occurrence - Grasslands,4424
+pc,82f02c1a-6f9d-4441-b2df-7bb59f9e84a2,Black-Tailed Prairie Dog Area of Occurrence - Grasslands,137ab45e-738b-4d8c-9abc-8d766b91ba97,Black-Tailed Prairie Dog Area of Occurrence - Grasslands - Data Dictionary,1836
+tbs-sct,83320390-7715-43bc-a281-2049bf5d4232,Official titles of Government of Canada departments and agencies,f0ca63e0-c15e-45b5-9656-77abe1564b1c,Official titles of Government of Canada departments and agencies,17863
+pc,8374ab94-6575-42c8-8043-947c26724858,Density of moose - Gros Morne,d582eb27-390d-43e0-af24-e83a43b4325e,Density of moose - Gros Morne - Data,10136
+pc,8374ab94-6575-42c8-8043-947c26724858,Density of moose - Gros Morne,58aa2602-6ab6-41ce-b4aa-dba9530805f2,Density of moose - Gros Morne - Data dictionary ,687
+pc,83db5def-45ce-49e8-bc7a-0862c670a7fc,American Badger - Yoho,344f9b58-605a-4587-a665-1f585d1f6f6c,American Badger - Yoho,214
+psc-cfp,83dcf122-d050-4def-8456-d23b718c6b22,Priority Entitlements,f8cc4ef5-39fd-407e-a52a-5de9a711cbe5,Priority entitlements (public service total) ,141840
+psc-cfp,83dcf122-d050-4def-8456-d23b718c6b22,Priority Entitlements,91947b62-867e-43b6-9bdd-a10d3b375b8d,"Medically released members of Canadian Armed Forces (CAF) and Royal Canadian Mounted Police (RCMP) and Surplus employees – New entitlements compared to appointments, by fiscal year",12294
+pc,840f975d-feae-418f-9507-f33be892ef7d,Stream Hydrology - Prince Edward Island,36f03bf2-8a24-4950-9c9e-6feb9d237d6e,Stream Hydrology - Prince Edward Island,31648986
+psc-cfp,845f9e76-d03e-4652-8f43-bb777ab1d52b,Population under the Public Service Employment Act,427efaed-60c6-477f-b561-5d9771ecd533,"Public Service Employment Act population, by year and tenure",12891
+psc-cfp,845f9e76-d03e-4652-8f43-bb777ab1d52b,Population under the Public Service Employment Act,39479da0-6966-4a79-82a7-17dfa0476af4,"Proportion of indeterminate employees aged less than 35 to indeterminate population under the Public Service Employment Act, by year",5082
+psc-cfp,845f9e76-d03e-4652-8f43-bb777ab1d52b,Population under the Public Service Employment Act,42f285e9-5085-4f38-98a2-1dcd2c0bad42,Public Service Employment Act population by organization and geographic area,783809
+pc,8481aa26-a577-49e0-9f55-5ce2df9864dc,Bank Swallows - Prince Edward Island,81280f21-d7f4-4f9b-9987-077343129a6d,Bank Swallows - Prince Edward Island ,42009
+pc,8481aa26-a577-49e0-9f55-5ce2df9864dc,Bank Swallows - Prince Edward Island,a23db9f1-8a88-43f4-8c38-ba253c2ed1a5,Bank Swallows - Prince Edward Island - Data Dictionary,1994
+pc,84ee93a7-ca28-4033-b140-ba507aef61cf,Rangeland Health - Prince Albert,e5075549-5e5d-4466-8e17-cc9130929d4f,Rangeland Health - Prince Albert - Data,19886
+pc,84ee93a7-ca28-4033-b140-ba507aef61cf,Rangeland Health - Prince Albert,3d9cc8b8-8479-4aef-817d-b05a43445b3a,Rangeland Health - Prince Albert - Data Dictionary,9339
+pc,856b9876-58f2-4629-b1a5-a43cc934a49c,Fresh Water Quality - Pacific Rim,4042170d-79d3-4caf-9bfd-59acc3aea00d,Freshwater Quality - Pacific Rim - Data,132682
+pc,856b9876-58f2-4629-b1a5-a43cc934a49c,Fresh Water Quality - Pacific Rim,1a085eca-383d-4c2a-8e49-3a2b8f317cc9,Freshwater Quality - Pacific Rim - Data Dictionary,628
+pc,85ce7cf5-358c-4c2e-964d-3abd42cb9f12,American Badger - Kootenay,0bd3ef55-860d-4ae9-82f3-6af61c1ffa60,American Badger - Kootenay,995
+pc,85e0ba82-b514-4cad-b262-7dd0f630898c,Forest Area Burned - Kootenay,0427e708-b575-4a4f-887f-8ace61ea3e0e,Forest Area Burned - Kootenay,16017
+tbs-sct,8634f1c9-597e-416d-91f2-df24d2ffbeea,Proactive Disclosure - Departmental Audit Committees,499383b6-cd2a-466a-9fcf-910d3e427700,Proactive Disclosure - Departmental Audit Committees (2018-2019-Q2 and later),1328361
+esdc-edsc,86a9d46f-5e4c-479a-bfb5-36ec15bcae42,"Average monthly payments for new Canada Pension Plan (CPP) disability beneficiaries by province, gender and calendar year ($)",be3756cb-d31f-4da4-99e9-3f4d97f2ed5d,"Average monthly payments for new Canada Pension Plan (CPP) disability beneficiaries by province, gender and calendar year",3474
+esdc-edsc,86a9d46f-5e4c-479a-bfb5-36ec15bcae42,"Average monthly payments for new Canada Pension Plan (CPP) disability beneficiaries by province, gender and calendar year ($)",33371ad9-8b14-4331-8589-2dfabf30814d,"Average monthly payments for new Canada Pension Plan (CPP) disability beneficiaries by province, gender and calendar year",3807
+esdc-edsc,8709504b-ecb0-4058-91b8-f4c35dac2049,Yearly Registered Education Savings Plan (RESP) Contributions by Forward Sortation Area ,6c3cb61c-6c62-412e-aa27-65da4e6ad619,Yearly Registered Education Savings Plan (RESP) Contributions by Forward Sortation Area ,103147
+esdc-edsc,8709504b-ecb0-4058-91b8-f4c35dac2049,Yearly Registered Education Savings Plan (RESP) Contributions by Forward Sortation Area ,e06a38f6-9de8-4476-b28b-895fda10fa92,Yearly Registered Education Savings Plan (RESP) Contributions by Forward Sortation Area ,103149
+pc,8724f153-b966-46c8-ae7c-ebfacd25e936,Area burned - Jasper,b7b81a1d-03a7-4003-9e99-8517415a81bb,Area burned - Jasper,18407
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,15f9967d-608d-41b2-bced-8d7e61a6d53f,By department (including all departments) ,5306566
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,d0437695-b1da-4bcd-bd4e-4eef0f62d8a8,By department and by Employment Equity Group: Women ,32059050
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,0eded731-2004-4f00-aa05-606801f5dafc,By department and by Employment Equity Group: Visible minorities ,20818641
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,77c9c20e-691b-4c13-8243-9cf9cf81c8dc,By department and by Employment Equity Group: Indigenous Peoples ,21026218
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,68c92f22-dc23-4027-a714-214600063ed6,By department and by First Official Language,18735121
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,cdabf3bd-cfca-42b0-a58f-1d963a1af5ec,By department and by Region ,63124446
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,95829e14-df60-4766-afd5-ae8864580266,By department and by Occupational group ,52471505
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,85ec7faf-90e5-4015-932b-f24fb97133b2,By department and by Age group ,64592020
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,a45a3101-33be-453b-b5e2-144d8c50a7a0,By department and by Years of Service,50316433
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,54b1b522-573f-469e-97f8-de9c75a46106,By department and by Tenure ,21149703
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,2ae9d18b-3ccc-409a-935b-197bf2a580d6,Data Visualization Dataset ,22792314
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,1478662e-17d0-4e3a-aacb-e9c4fb87ae8f,Response profile data ,59097
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,d583d90e-4aca-43b3-95cb-5137c239d05d,List of questions ,101026
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,dca15e16-3a29-4fc6-84e7-73032062a239,List of departments ,9841
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,05442d31-89b6-4b97-a40f-7ee8f1cf756e,By department and by diploma ,84402451
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,bf726802-12f3-4337-a5a0-facd70299a28,By department and by marital status,66512792
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,0c3a30e1-e97a-4f47-a1f6-7ae8976b17d1,By department and by 2SLGBTQIA+ identity,32277683
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,5daa5fd7-6597-4edf-93b5-ea2b43854df4,By department and by religion,90286235
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,1c3e883f-b5c4-4ac8-96f0-f9757139bd13,By department and by visible minority subgroup,74191687
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,ed359432-8f40-4096-a0fd-1f6bc44c7490,By department and by Indigenous subgroup,22349284
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,1a6f545e-d7cf-4a46-abd2-ad29cf11b5ab,By department and by type of disability,98264331
+psc-cfp,88f45a5c-bc57-4483-bc85-2c19bc342039,2023 Staffing and Non-Partisanship Survey,be6fe4fa-37f7-4224-8108-095e66008b05,By department and by Employment Equity Group: Persons with disabilities,29914418
+pc,89383791-0478-48f5-8f70-d2d02d8fbd2f,Non-native mammals - Gwaii Haanas,9369ecd3-998c-4b4e-9b12-edfdb1697d62,Non-native mammals - Gwaii Haanas,2368
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,c05bdc4e-21fa-4c8b-a0f0-95816a8049e5,Charities Businesses Directors/Officers,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,a0265da3-0146-48c0-a0f5-50920e1b3d2a,Financial data,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,dfb25c36-8830-4998-8b97-12d5d0b85dc5,General information ,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,f1e0a666-c065-4c4d-8d0f-e8a446f3e6b1,Non-Qualified donees,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,f50a8d04-be97-43c7-8491-1e5df69a6f79,Private/Public Foundations,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,4444d0d1-1cbe-46f3-89e1-0731c95e3e16,Activities outside Canada – Countries where program was carried,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,80a3820b-55cd-45bb-8b51-c71730490988,Activities outside Canada – Details on financial,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,8005fffd-ac1f-4abf-ad8a-2b1e89c2117e,Compensation,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,c24bb592-d8be-4983-b64d-2afc0c9bea2e,Political Activities – Funding,
+cra-arc,8940f53e-74e5-486c-b5ed-458a935d98aa,2016 List of charities,48b6c786-d9ff-436f-bbe3-1457312b742a,Political Activities – Resources,
+opc-cpvp,897a64fd-619d-48cc-b056-c9f6484b63b1,2022-23 Survey of Canadians on privacy-related issues,e6a3bcb8-af6b-48cc-8e1c-e0a573391a86,2022-23 Survey of Canadians on privacy-related issues - Dataset,192465
+opc-cpvp,897a64fd-619d-48cc-b056-c9f6484b63b1,2022-23 Survey of Canadians on privacy-related issues,6815c38c-ccd5-4794-836c-87e4bd8e2b9a,2022-23 Survey of Canadians on privacy-related issues - Dataset,192470
+vac-acc,89b5bb71-47f1-42ae-a08f-a532a05a8773,2021-22 Departmental Results Framework,884e71b1-d729-43ef-bbe5-47e02edc0641,Office of the Veterans Ombud 2022 Report Card,22870
+vac-acc,89b5bb71-47f1-42ae-a08f-a532a05a8773,2021-22 Departmental Results Framework,c6128a24-3738-488d-94b2-f3463d66964e,Office of the Veterans Ombud 2022 Report Card,27756
+cfia-acia,8a855cc4-3ee3-41ed-bd38-e748d15043c7,Food Microbiology - Targeted Surveys - 2015 - 2018 Bacterial Pathogens in Powdered Infant Formula - Final Report,f079d589-35fa-417a-b4f5-26c88035ac5a,Food Microbiology - Targeted Surveys - 2015 - 2018 Bacterial Pathogens in Powdered Infant Formula - Final Report,3833577
+pc,8a8fe186-85d5-46f9-99ee-2f04cc2a192f,Water Quality - Ivvavik,c8e12402-2c0c-4ef3-b5c6-007767581229,Water Quality - Ivvavik - Firth at the mouth –Dissolved metals - 2001-2017 - data - 1,3062
+pc,8a8fe186-85d5-46f9-99ee-2f04cc2a192f,Water Quality - Ivvavik,fd9ead4f-0909-4c7a-81da-9ce45a480c9f,Water Quality - Ivvavik - Firth at the mouth –total metals - 2001-2017 - data - 2,3631
+pc,8a8fe186-85d5-46f9-99ee-2f04cc2a192f,Water Quality - Ivvavik,28760349-1dbc-4619-8e4a-10ee184a1c33,"Water Quality - Ivvavik - Firth at the mouth - Nutrients, Physicals, and Major Ions - 2001-2017 - data - 3",3333
+pc,8a8fe186-85d5-46f9-99ee-2f04cc2a192f,Water Quality - Ivvavik,90972fff-8c9b-4263-b461-fa980c7cdb75,"Water Quality - Ivvavik - Sheeps Creek - Nutrients, Physicals, and Major Ions- 2011-2017 - data - 4",2218
+pc,8a8fe186-85d5-46f9-99ee-2f04cc2a192f,Water Quality - Ivvavik,3b3567c4-f73b-40a0-8bc8-888dd2a4c935,Water Quality - Ivvavik - Sheeps Creek –dissolved metals - 2011-2017 - data - 5,2503
+pc,8a8fe186-85d5-46f9-99ee-2f04cc2a192f,Water Quality - Ivvavik,84d05540-6965-4f20-884e-ca3ecf00af4b,Water Quality - Ivvavik - Sheeps Creek –total metals - 2011-2017 - data - 6,2496
+pc,8a8fe186-85d5-46f9-99ee-2f04cc2a192f,Water Quality - Ivvavik,5c7195ad-0ab0-4523-ac89-f65cfb0769dc,Water Quality - Ivvavik -  2001-2017 - data dictionary,1002
+pc,8b498a37-dde3-4306-ad18-f96a812b1b99,Bog Dynamics - Kouchibouguac,e1c3702c-7135-4c75-897f-04de02992b0b,Bog Dynamics - Kouchibouguac - Water Quantity - Data Dictionary 1,1304
+pc,8b498a37-dde3-4306-ad18-f96a812b1b99,Bog Dynamics - Kouchibouguac,8f9a1080-1fba-473c-b46b-3e145ebbb97c,Bog Dynamics - Kouchibouguac - Water Quality - Data 2,6386
+pc,8b498a37-dde3-4306-ad18-f96a812b1b99,Bog Dynamics - Kouchibouguac,0bbeac6d-31fc-459a-8fe9-06a587641e8c,Bog Dynamics - Kouchibouguac - Water Quality - Data Dictionary 1,1775
+pc,8b498a37-dde3-4306-ad18-f96a812b1b99,Bog Dynamics - Kouchibouguac,468af54f-70cf-40c2-9970-f203de90dc94,Bog Dynamics - Kouchibouguac - Vegetation - Data 3,12871
+pc,8b498a37-dde3-4306-ad18-f96a812b1b99,Bog Dynamics - Kouchibouguac,0a3cfb0a-9ce1-4893-b789-9408af7fb59a,Bog Dynamics - Kouchibouguac - Vegetation - Data Dictionary 3,12761
+pc,8b941042-ccf5-47db-80ce-69520ab9c7a7,Mountain Goats - Banff,7d2b7b99-cb66-4bdf-8d94-3cad426d9fa0,Mountain Goats - Banff,357
+pc,8c3fb829-44c6-4cb4-bb6d-d1e8ce32d607,Infrastructure Footprint - Prince Edward Island,13fb3c26-c730-4d4f-b728-a3076475f74b,Infrastructure Footprint - Prince Edward Island - 1,33691
+pc,8c3fb829-44c6-4cb4-bb6d-d1e8ce32d607,Infrastructure Footprint - Prince Edward Island,c801f704-9009-46b0-b267-7af5e21cefec,Infrastructure Footprint - Prince Edward Island - Data Dictionary - 2,737
+ssc-spc,8ceaa13d-603f-4959-a888-fb31fcd20182,Employment Equity,aae683dc-c33c-47c9-8ffe-7b6bdef8ef40,Employment Equity ,898
+ssc-spc,8ceaa13d-603f-4959-a888-fb31fcd20182,Employment Equity,7a743875-2b16-4464-ae28-524def42e692,Employment Equity,913
+pc,8cfbac86-d63c-432e-a23d-3419db61f111,Yoho_NP_ForestAlpine_Songbird Point Counts ,8873c40f-e979-4a1d-bcee-eccf1e2790fd,Forest -  Avian Species Relative Abundance - Data,1237881
+pc,8cfbac86-d63c-432e-a23d-3419db61f111,Yoho_NP_ForestAlpine_Songbird Point Counts ,7a8f0808-56a6-4eab-bb39-dea08786fd64,Forest -  Avian Species Relative Abundance - Data Dictionary,15264
+pc,8d2849d9-a723-46c1-b94b-ed4a76e78195,Caribou population - Jasper,f9a392dc-aa09-41bd-ae74-c8de9ed5d42b,Caribou population - Jasper,31466
+pc,8d2849d9-a723-46c1-b94b-ed4a76e78195,Caribou population - Jasper,70a477f3-80ea-4139-9fcf-5f0ccc316718,Caribou population - Jasper - Data Dictionary,345
+pc,8d83a8f8-672e-41cc-ae3c-92db4aa74b89,Trees - Fundy,15f74d75-8857-4743-bdb7-09e9cc1b5fef,Trees - Fundy - 1,322182
+pc,8d83a8f8-672e-41cc-ae3c-92db4aa74b89,Trees - Fundy,4ecc6ac9-30d0-4247-b167-bf31c9cdc9bd,Trees - Fundy - 2,92837
+pc,8d83a8f8-672e-41cc-ae3c-92db4aa74b89,Trees - Fundy,0a2a7047-ab7c-42a2-8b8b-79c8d822f618,Trees - Fundy - Data Dictionary 1,3325
+pc,8d83a8f8-672e-41cc-ae3c-92db4aa74b89,Trees - Fundy,7e73da76-88e5-4fd4-ae03-e47fbe92043b,Trees - Fundy - Data Dictionary 2,4341
+ssc-spc,8dc0ad19-a5d3-4d22-8184-898940d61c75,Percentage of Hardware Requests Fulfilled Within Established Service Level Standards,3ffd3d35-a99b-4aa3-aa7f-c1e7374c988f,Percentage of hardware requests fulfilled within established service level standards,27918
+ssc-spc,8dc0ad19-a5d3-4d22-8184-898940d61c75,Percentage of Hardware Requests Fulfilled Within Established Service Level Standards,9d4be37d-9394-4e6a-9aba-429254150475,Percentage of hardware requests fulfilled within established service level standards,29879
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,ef47939d-475e-4833-b032-222fe13c9cb7,Charities Businesses Directors/Officers,54370391
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,028772e7-dffe-43d0-bd7f-85c032acada3,Financial data,18263441
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,5e58be8c-8d58-4b99-b643-88852ae2f98f,Identification,12172574
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,118c60a8-8263-48c4-91a9-491c98f6bc89,Charitable Programs,29545901
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,47128846-8b69-4a87-b96b-f2a13467cba2,Private/Public Foundations,3057028
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,d34934ff-54db-45a8-a2a4-61823cf9c47e,Activities outside Canada – Countries where program was carried,425418
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,67633a8d-43bc-40dd-86df-990d0b332ea2,Activities outside Canada – Details on financial,3397578
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,2b30d435-1ff5-4598-a844-8211f1086224,Activities outside Canada - Exported goods,78521
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,0ca53941-1518-4809-a9bc-842b836f1ccb,Activities outside Canada - Financial resources used,391060
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,0f538b56-845e-40e8-a608-aa887f85726c,Compensation,4292747
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,c94aa933-513f-4706-a593-38613d8d3c27,Non-cash gifts (gifts in kind) received,4108124
+cra-arc,8e4fbdda-f73e-4c49-b0f3-79b86d4a81fb,2011 List of charities,49e0746f-628d-46f8-9368-fcf4bcb599ae,Charity Contact Web Addresses,1350339
+dfo-mpo,8e6984b6-16a4-47cf-8719-8b36ad95b38d,Commercial Fisheries - Quota Reports,322c2065-b166-4573-8746-aae42cdb1f25,2002 Argentine,356375
+dfo-mpo,8e6984b6-16a4-47cf-8719-8b36ad95b38d,Commercial Fisheries - Quota Reports,0403aa11-ebac-4cd9-ae97-231f664ba966,2004 Skate,64565
+pc,8eb3dc2c-b5a4-48f8-9938-bdd463856794,Black swift - Jasper,17b7d825-51ac-4000-a278-bfc575382cd9,Black swift - Jasper,13866
+pc,8eb3dc2c-b5a4-48f8-9938-bdd463856794,Black swift - Jasper,d6f7baa3-2926-4af3-a4c3-fbefdb56026a,Black swift - Jasper - Data Dictionary,335
+pc,8f14b70b-3b24-4dcf-b292-cbf71bd29c07,Canadian Aquatic Biomonitoring Network - Waterton Lakes - Freshwater,09ee6eba-daef-4a41-8d4a-241e6be95279,Stream Biotic Health - Waterton Lakes - CABIN sample data  - 1,1118
+pc,8f14b70b-3b24-4dcf-b292-cbf71bd29c07,Canadian Aquatic Biomonitoring Network - Waterton Lakes - Freshwater,e296a779-abe1-4da7-9d7d-5bd1f5e4bd75,Stream Biotic Health - Waterton Lakes - CABIN sample data  dictionary - 2,386
+pc,8f4edee0-8771-4de3-9bcd-e96b4804450c,Inventory of active beaver colonies - Gros Morne,9d6e71f1-f2e5-4f92-a29e-879fffb1af8d,Inventory of active beaver colonies - Gros Morne - Data,11236
+pc,8f4edee0-8771-4de3-9bcd-e96b4804450c,Inventory of active beaver colonies - Gros Morne,2bf1e551-a3d0-4407-bcf3-35c7d4c7e933,Inventory of active beaver colonies - Gros Morne - Data dictionary ,1362
+vac-acc,8f810399-6380-4cd1-9ad1-0465a8c2a5ac,Wait Time Tool,bb405090-f6a7-4de6-8b83-386aa1321350,2020-04-01 to 2020-06-30,21504
+vac-acc,8f810399-6380-4cd1-9ad1-0465a8c2a5ac,Wait Time Tool,f1e6af7e-934b-4850-83b6-c62ffe864687,2020-04-01 to 2020-06-30,23842
+vac-acc,8f810399-6380-4cd1-9ad1-0465a8c2a5ac,Wait Time Tool,887683ee-5bb1-4a6b-9333-696ad5d0bb59,2020-07-01 to 2020-09-30,23153
+vac-acc,8f810399-6380-4cd1-9ad1-0465a8c2a5ac,Wait Time Tool,597e3266-ac2f-43fb-9f0b-388d75cfd0d3,2020-07-01 to 2020-09-30,25623
+vac-acc,8f810399-6380-4cd1-9ad1-0465a8c2a5ac,Wait Time Tool,26aab3e7-5dda-4ea7-b7be-afdef0a2fbfc,2020-10-01 to 2020-12-31,21117
+vac-acc,8f810399-6380-4cd1-9ad1-0465a8c2a5ac,Wait Time Tool,4d1b6c8b-afd2-4ec0-b00f-377700700d20,2020-10-01 to 2020-12-31,23585
+pc,8f8864b3-384c-490f-be74-12d08495ac56,Prescribed Fire (CoRe),1537498b-9527-4a9f-b337-146305520526,Prescribed Fire (CoRe),310
+pc,8fa8aa09-380a-4e8b-9bb2-9f27c2cf8847,Shrub Extent – Kluane,0320b108-601e-45d6-9f7a-d367ed593786,Shrub Extent - Kluane-1,479050
+pc,8fa8aa09-380a-4e8b-9bb2-9f27c2cf8847,Shrub Extent – Kluane,9f5fad0e-da0f-40e5-9c99-bcabfd55bb5f,Shrub Extent - Kluane-2,251989
+pc,8fa8aa09-380a-4e8b-9bb2-9f27c2cf8847,Shrub Extent – Kluane,68b2645d-6baf-46d3-823a-2097f21cfa5e,Shrub Extent - Kluane-3,2209
+pc,9046af59-81c4-4759-8979-f6185af8387d,Benthic Invertebrates - Tuktut ,c80486d2-75d5-4b90-b926-b24afb8d747e,Benthic Invertebrates - Tuktut - 2009-2017 - data ,23747
+pc,9046af59-81c4-4759-8979-f6185af8387d,Benthic Invertebrates - Tuktut ,2211eb38-adc9-484c-b4ad-d8bb25ebdf56,Benthic Invertebrates - Tuktut - 2009-2017 - data dictionary,3259
+cfia-acia,906cd35c-d396-4999-9a9f-f5351796661f,2015 – 2017 Glyphosate Testing Data,11318cc2-f9ef-4774-8b54-4716c18cc340,2015 – 2017 Glyphosate Testing Data,3244502
+pc,90d61a9d-4fd5-4247-bbdb-b3c5e85a0272,Plant productivity and growing season change - Ukkusiksalik,b5d36845-aa4f-4130-bf32-b4d3f55a90b9,Plant productivity and growing season change - Ukkusiksalik,2223
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),d96bb679-2e2e-4d91-b620-c319a7d4fe25,Canadian Vehicle Specifications (CVS) - Model Year 2023,10209
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),2b7d2ab2-c50a-4c92-b83c-e9bc05f8b758,Canadian Vehicle Specifications (CVS) - Model Year 2022,101627
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),c31eccaf-643c-484f-810a-5c085f6b87bf,Canadian Vehicle Specifications (CVS) - Model Year 2021,99966
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),1445673a-904e-4947-afdc-74bf3d60e32a,Canadian Vehicle Specifications (CVS) - Model Year 2020,101693
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),0f4988f0-a0bc-41fb-b94a-798607ca7240,Canadian Vehicle Specifications (CVS) - Model Year 2019,101161
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),e53470a9-dbf8-49b7-816a-f64128ca8cee,Canadian Vehicle Specifications (CVS) - Model Year 2015,98459
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),58a57d56-477a-4309-8118-33fb4c0fe5ed,Canadian Vehicle Specifications (CVS) - Model Year 2014,90321
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),6fe824d9-8ea6-4a69-9d21-86f2f973025f,Canadian Vehicle Specifications (CVS) - Model Year 2013,92628
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),83c88aee-388a-4994-9865-547a2cfe0014,Canadian Vehicle Specifications (CVS) - Model Year 2012,90231
+tc,913f8940-036a-45f2-a5f2-19bde76c1252,Canadian Vehicle Specifications (CVS),76ae33f3-da9e-48f0-9c00-227e61f9431c,Canadian Vehicle Specifications (CVS) - Model Year 2011,85477
+pc,91553307-1a48-4aef-a6d3-1011330accaf,European green crab - Kejimkujik,2bea72ed-4d48-4865-a519-6d321e8f5cc7,European Green Crab - Kejimkujik -Population Survey Data - 1,2601598
+pc,91553307-1a48-4aef-a6d3-1011330accaf,European green crab - Kejimkujik,094fb6e6-0f51-4905-8517-4b783f18e82d,European Green Crab - Kejimkujik - Trap Location Information - 2,984
+pc,91553307-1a48-4aef-a6d3-1011330accaf,European green crab - Kejimkujik,e8bcb107-6380-4586-ac77-d5f48581bc0b,European Green Crab - Kejimkujik - Data Dictionary - 3,848
+opc-cpvp,923cbbdc-afb2-48dc-a343-ad75d231026b,2021-22 Survey of Canadian businesses on privacy-related issues,3f967942-a6a2-4d1e-b2af-cb57867f7e8a,2021-22 Survey of Businesses Dataset,140322
+opc-cpvp,923cbbdc-afb2-48dc-a343-ad75d231026b,2021-22 Survey of Canadian businesses on privacy-related issues,5c08fdc2-cc6b-4b30-9511-94598654f0f8,2021-22 Survey of Businesses Dataset,140322
+pc,9288e209-049b-4fa0-a021-9e768d9f785f,Barrier beach stability - Kejimkujik,11b4d6c6-b810-4380-97f4-efd999fdf28d,Barrier Beach Stability - Kejimkujik - Transect Data,39551
+pch,92984c11-6fd4-40c4-b23c-e8832e1f4cd5,"Data on funding provided in 2016-2017 and 2017-2018 by the Canada Arts Presentation Fund, Canadian Heritage",148841f0-11c9-4f45-8700-d0a4717dea2f,CAPF_EN,322134
+pc,92ac974e-d7f8-46d7-aac7-bd5682a6ad6b,Stream Hydrology - Terra Nova,96f0b053-9d2b-4607-90f2-dcc715f99fc3,Stream Hydrology - Terra Nova,3746272
+pc,932b4e4d-9c09-4864-8646-24db93fc1b36,Mammals - Jasper,946766c4-c5bf-415d-826e-20ba9a27ef0a,Mammals - Jasper,2411322
+pc,932b4e4d-9c09-4864-8646-24db93fc1b36,Mammals - Jasper,1ebecd7f-63e7-4e13-8404-aec5d42a497b,Mammals - Jasper - data dictionary,4526
+tbs-sct,933c7f9d-deb0-4367-940d-06c38f494153,Open Government Portal Department List,04cbec5c-5a3d-4d34-927d-e41c9e6e3736,Government of Canada Department List,47699
+pc,9360db43-2d1c-4bc4-9cbd-61ce42b2cff8,Situation of the Black Bear - La Mauricie,9c8e2714-4d33-431b-8e3e-427c480ff628,Black Bear - Data 1,1568
+pc,9360db43-2d1c-4bc4-9cbd-61ce42b2cff8,Situation of the Black Bear - La Mauricie,21f3a0af-76df-4296-962d-1fd1ccbabcfa,Black Bear - Data 2,1372
+pc,9360db43-2d1c-4bc4-9cbd-61ce42b2cff8,Situation of the Black Bear - La Mauricie,1691faf8-0510-4af2-9ae8-f4dff37b2458,Black Bear - Data Dictionary,270
+esdc-edsc,93f81da5-a9e0-477d-b73f-7f54952ce580,Workforce Population of Designated Groups by Employment Equity Occupational Groups,4ee599c8-be4c-497c-829a-33401883ec30,"Workforce Representation of 4 Designated Groups by Canada, Provinces, and Territories",1465
+esdc-edsc,93f81da5-a9e0-477d-b73f-7f54952ce580,Workforce Population of Designated Groups by Employment Equity Occupational Groups,e360f637-c1e2-4dc8-b1cf-7c9a939293b2,"Workforce Representation of 4 Designated Groups by Canada, Provinces, and Territories",1523
+esdc-edsc,93f81da5-a9e0-477d-b73f-7f54952ce580,Workforce Population of Designated Groups by Employment Equity Occupational Groups,147d8ce7-e501-4858-88ee-40caca38ceb4,Workforce Population of 3 Designated Groups by Employment Equity Occupational Groups,27184
+esdc-edsc,93f81da5-a9e0-477d-b73f-7f54952ce580,Workforce Population of Designated Groups by Employment Equity Occupational Groups,fc8ce039-3f03-401a-9763-1e6184bdb41b,Workforce Population of Persons with Disabilities by Employment Equity Occupational Groups,14235
+esdc-edsc,93f81da5-a9e0-477d-b73f-7f54952ce580,Workforce Population of Designated Groups by Employment Equity Occupational Groups,70199685-97d7-4399-8406-2aac6fd43b9c,Workforce Population of 3 Designated Groups by Employment Equity Occupational Groups,28869
+pc,9458e765-9cf1-4091-aa02-285df5e65bb3,Greater Sage-Grouse Abundance - Shrublands,dcca6b68-1c6e-4fd8-aa31-63bda1b6750d,Greater Sage-grouse - Grasslands,29481
+pc,9458e765-9cf1-4091-aa02-285df5e65bb3,Greater Sage-Grouse Abundance - Shrublands,3d924299-7f19-4899-91c2-140aa5dfd54a,Greater Sage-grouse - Grasslands - Data Dictionary,1370
+pc,9517146e-a03b-4ca8-8492-94b867bcaed8,Inland Lake Water Quality - Bruce Peninsula,f01519db-7476-480a-957e-3daf442d0d10,Inland Lake Water Quality - Bruce Peninsula ,130088
+pc,954d5cb7-3b37-427b-96d0-13f7aa5b6d44,Coastal Process - Erosion and Accretion - Gwaii Haanas,af38361b-e4a1-40c4-b423-1e520302fc0b,Coastal Process - Erosion and Accretion - Gwaii Haanas,1842
+pc,95b9c052-df09-4377-a5f4-851c2cf5906f,Wetland water quantity - Kejimkujik,0b418cee-3a88-4584-b58c-84dce2b1eed5,Wetland Water Quantity - Kejimkujik - Water Level Data - 1,2517614
+pc,95b9c052-df09-4377-a5f4-851c2cf5906f,Wetland water quantity - Kejimkujik,f72eacd9-f534-4482-8533-99d411408aa1,Wetland Water Quantity - Kejimkujik - Site Information Data - 2,498
+pc,95e34b0d-5142-41a3-8a38-a8ab85507fb0,Dwarf birch growth change - Torngat Mountains,4a4ae0ff-e742-4390-97b0-7089ed68b0d4,Dwarf birch growth change - Torngat Mountains - Data,22479
+pc,95e34b0d-5142-41a3-8a38-a8ab85507fb0,Dwarf birch growth change - Torngat Mountains,1ffe3804-dca5-446e-a418-c392759cf99a,Dwarf birch growth change - Torngat Mountains - Data dictionary,556
+pc,95edf34a-c881-475a-869f-0aef5ebed210,Juvenile Salmonid Populations- Pacific Rim,8b79fe30-2494-4330-b6cd-64d21a55fa06,Juvenile Salmonids - Pacific Rim - Data,4626
+fin,96bbfded-940e-4ac9-a638-c7aa12d00076,"Report on Federal Tax Expenditures - Concepts, Estimates and Evaluations 2022",4ddcdb14-fd77-4101-bdb2-2de20913023a,Data tables,83249
+pc,96d26ef3-bf21-4ea5-a9c9-80b909fbcbc2,Parks Canada attendance 2019-20,77acd8a2-1b71-4bda-bbd1-894880255cf1,Parks Canada attendance 2019-20,5855
+cfia-acia,975b6624-e394-4c12-9cb7-cc1443eea60e,"Food Microbiology – Targeted Surveys – Final Report – Bacterial Pathogens and Indicators in Raw Non-Soy Plant-based Meat Alternatives - April 1, 2020 to March 31, 2023",af78699b-d3bf-4e11-a3ea-c523dc572af5,"Food Microbiology – Targeted Surveys – Final Report – Bacterial Pathogens and Indicators in Raw Non-Soy Plant-based Meat Alternatives - April 1, 2020 to March 31, 2023",1543598
+pc,97b387e2-58f5-4401-8901-1d22ff130131,Balsam fir density - Terra Nova,5cd780df-4ab2-4be3-b10d-3b6b9e1a996c,Balsam fir density-3,16514
+pc,9891002d-4038-4c6b-bc5d-419dc1580096,Frogs and Toads - Point Pelee,c2605d19-dd98-44b5-9f57-b5ebe3654e75,Frogs and Toads - Point Pelee - Monitoring Data,95916
+pc,9891002d-4038-4c6b-bc5d-419dc1580096,Frogs and Toads - Point Pelee,a90481a1-e49c-4e5c-9be1-9151e978cb15,Frogs and Toads - Point Pelee - Monitoring Data Dictionary,6143
+tbs-sct,98abeb62-7c76-4dfb-a134-1551f55ede55,Proactive Disclosure - Use of Administrative Aircraft ,1495406e-338c-43ec-9995-ec8d8c90d17e,Use of Government Administrative Aircraft,7626
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,026e45b4-eb63-451f-b34f-d9308ea3a3d9,Battery-electric vehicles 2012-2025 (2024-12-24),102162
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,0b0f5a42-b00b-4b6a-9185-4d4de1424801,Battery-electric vehicles 2012-2025 (2024-12-24),105981
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,8812228b-a6aa-4303-b3d0-66489225120d,Plug-in hybrid electric vehicles 2012-2025 (2024-12-24),45432
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,fcccabad-e478-45b0-8d34-a25b77028c1d,Plug-in hybrid electric vehicles 2012-2025 (2024-12-24),46901
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,d589f2bc-9a85-4f65-be2f-20f17debfcb1,2025 Fuel Consumption Ratings (2024-12-24),
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,2e1a460f-464d-44b7-b711-8870a6eef7b9,2025 Fuel Consumption Ratings (2024-12-24),
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,edba4afa-dc19-480c-bbe4-57992fc9d0d6,2024 Fuel Consumption Ratings (2024-09-11),65828
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,476872f0-cc09-42d1-a9d3-9fab9ffde53c,2024 Fuel Consumption Ratings (2024-09-11),68616
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,b6100f60-5e63-437d-b122-db76c467c0a7,2023 Fuel Consumption Ratings (2024-08-30),72275
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,e2320336-2e19-4869-9fa8-6d1846a1c850,2023 Fuel Consumption Ratings (2024-08-30),75413
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,87fc1b5e-fafc-4d44-ac52-66656fc2a245,2022 Fuel Consumption Ratings (2024-08-30),83539
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,665ef056-5adc-47d8-bd9f-53c42c80c980,2022 Fuel Consumption Ratings (2024-08-30),87026
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,f2e53a2b-e075-473a-9a9c-5d7bef68d07d,2021 Fuel Consumption Ratings (2023-02-03),82382
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,5d298ed1-d239-44ea-af7a-e15d4ce72941,2021 Fuel Consumption Ratings (2023-02-03),85805
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,56a89c09-d609-41cd-8838-9dd9905d3cfc,2020 Fuel Consumption Ratings (2023-02-03),79802
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,d1a5f5b0-5956-43f8-8126-a591611abfc7,2020 Fuel Consumption Ratings (2023-02-03),83159
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,332be680-9577-42c6-8c47-a0380ef48c5e,2015-2019 Fuel Consumption Ratings,435989
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,7edcbaf3-de87-4b2a-acd3-305655c09eb7,2015-2019 Fuel Consumption Ratings,453538
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,2309538b-53d1-4635-a88e-e237bfcef7a2,2005-2014 Fuel Consumption Ratings,844374
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,2be09539-286e-4b69-9ff0-2d9c3f1c4c71,2005-2014 Fuel Consumption Ratings,874806
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,42495676-28b7-40f3-b0e0-3d7fe005ca56,1995-2004 Fuel Consumption Ratings,577615
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,67a7f9ee-9c47-43a6-ab06-5e7242e12638,1995-2004 Fuel Consumption Ratings,598083
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,29bcf157-9297-4d6a-9695-dfd816bc32ca,(Original Fuel Consumption Ratings 1995-2014),1274103
+nrcan-rncan,98f1a129-f628-4ce4-b24d-6f16bf24dd64,Fuel consumption ratings,b882bfc2-569d-452c-882a-d84eb9da6982,(Original Fuel Consumption Ratings 1995-2014),1305906
+pc,98f9ac9c-7e0f-4495-ba76-9b099cfb1366,Aquatic Frogs - La Mauricie,f4b85562-a95e-4d9e-9f05-572a158becb0,Aquatic Frogs - La Mauricie - Data,43920
+pc,98f9ac9c-7e0f-4495-ba76-9b099cfb1366,Aquatic Frogs - La Mauricie,88c92424-f77f-45bb-bfa3-dcec91dfbee5,Aquatic Frogs - La Mauricie - Data dictionary,593
+cfia-acia,9938fee0-2c20-4277-b73f-a15d981d98fe,Federally Registered Meat Establishments and their Licensed Operators,6298fe92-c278-4f88-84cd-d3a2da161e1e,Federally Registered Meat Establishments and their Licensed Operators,152664
+pc,99405a59-ec96-4a80-8208-dcc3ebc6396b,Deer Browse - Summer Woody - Thousand Islands,30ebe9ac-e5e8-4864-a420-a1f9fa5afa55,Deer Browse - Summer Woody - Thousand Islands - Data,92984
+pc,99405a59-ec96-4a80-8208-dcc3ebc6396b,Deer Browse - Summer Woody - Thousand Islands,a5267b15-184a-4689-848e-34bb36846f3a,Deer Browse - Summer Woody - Thousand Islands - Data Dictionary,388
+cfia-acia,9b01257e-f683-40df-9cfe-f3c9296c5be5,"CFIA Undeclared Milk, Gluten, and Soy in Juices - 2014-2015",d8eb593c-17b4-4197-b983-b6becf4223c2,"CFIA Undeclared Milk, Gluten, and Soy in Juices - 2014-2015",239803
+pc,9b5fdd42-16c8-497c-9a04-fbf4e35aa6f1,Streams - Benthic Invertebrates - Pukaskwa,9476db0b-f589-4bfb-ab03-ddc853287969,Streams - Benthic Invertebrates - Pukaskwa,3881
+wd-deo,9b9dbdd4-e788-4e72-aeed-8030b212fd12,Number of communities benefitting from Community Economic Growth projects,aede4602-3728-4722-bee6-98cf0c11ab46,CEG Projects_e.csv,177
+tbs-sct,9c36431e-d916-498d-9779-0c52ce840293,Data Reference Standard on Person(s): sex assigned at birth,ab457ba4-4a80-476b-8608-c57c52d59bd1,reference data table for sex assigned at birth,592
+wd-deo,9c3f5337-04b7-4486-9420-7f2b93baf10f,Value of International Business Activity Facilitated by WD,50dac711-88d2-4d66-a1c8-f3c7ef6f80d9,IB Facilitated_e.csv,203
+pc,9ceda932-d147-463f-bf8e-e36dc72e01b2,Forest Disturbance - Pukaskwa,ae8fa71c-fb13-4871-ad50-b9ffd316ebea,Forest Disturbance - Pukaskwa,18417
+pc,9ceda932-d147-463f-bf8e-e36dc72e01b2,Forest Disturbance - Pukaskwa,c22345ff-a7b1-4c37-94e2-a6fa21a3eaa3,Forest Disturbance - Pukaskwa - Data Dictionary,694
+pc,9df64249-f5d0-4334-826c-2e82f0aa3326,Sprague's Pipit Abundance - Grasslands,b76d0b04-98a7-4295-b4cd-9649f5308851,Sprague's Pipit Abundance - Grasslands,316755
+pc,9df64249-f5d0-4334-826c-2e82f0aa3326,Sprague's Pipit Abundance - Grasslands,75742619-5c23-401f-9f89-79019310b8e5,Sprague's Pipit Abundance - Grasslands - Data Dictionary,1090
+pc,9e02610f-3b3f-4fcc-b47e-3294e68cf711,Peak Flow Rate - Grasslands,2eac8958-ccbf-4400-b078-2d73d4d3299d,Peak Flow Rate - Grasslands,4012
+pc,9e3080d1-704b-497a-8998-684f0f393a37,Forest Loss - Gwaii Haanas,a4d5de76-16ff-4cbe-9e04-a7e65c0f378d,Forest Loss - Gwaii Haanas,1175
+pc,9e391ec0-5cff-495f-91a2-74f8c860e2f5,Harlequin duck abundance and brood productivity - Torngat Mountains,61ca4f57-e54f-4a9d-9aa5-05652c352af2,Harlequin duck abundance and brood productivity - Torngat Mountains - Data,11362
+pc,9e391ec0-5cff-495f-91a2-74f8c860e2f5,Harlequin duck abundance and brood productivity - Torngat Mountains,69ababcc-0dbe-4452-a5b6-9def99f39f59,Harlequin duck abundance and brood productivity - Torngat Mountains - Data dictionary,2676
+esdc-edsc,9e394e89-8929-442b-ab45-4f0cb08f4da5,"Average monthly payments for Canada Pension Plan (CPP) disability beneficiaries by province, gender, and calendar year ($)",39923648-1c00-465d-b726-42b2bf8f4100,"Average monthly payments for Canada Pension Plan (CPP) disability beneficiaries by province, gender, and calendar year",3363
+esdc-edsc,9e394e89-8929-442b-ab45-4f0cb08f4da5,"Average monthly payments for Canada Pension Plan (CPP) disability beneficiaries by province, gender, and calendar year ($)",9782e800-9230-46ab-9433-d80bff630418,"Average monthly payments for Canada Pension Plan (CPP) disability beneficiaries by province, gender, and calendar year",3696
+tbs-sct,9e57c237-13af-4c99-a2c1-88eee597f9b1,Public Service Vaccination and Accommodations Status,0648d7b7-8bfe-4cc1-be89-df754c8a1d52,dataset,6034
+pc,9ebb8645-52de-4668-8e71-3517d97608f7,Subalpine Wildflowers - Mount Revelstoke,41af919d-747e-420c-a51b-350ced8b2343,Subalpine Wildflowers - Mount Revelstoke,51561
+pc,9ebb8645-52de-4668-8e71-3517d97608f7,Subalpine Wildflowers - Mount Revelstoke,a8442237-1824-4289-97ea-22c5906a6433,Subalpine Wildflowers - Mount Revelstoke - data dictionary,935
+pc,9ef5c30d-80fa-47ea-91e1-0c7c52ce2e32,Common Loon - La Mauricie,c4601ab4-2b0f-4a5e-961d-2082a2eab35d,Common Loon - La Mauricie,35949
+tbs-sct,9f9501f3-8188-4386-87ba-50730a979044,2022/2023 Public Service Employee Survey Results,526ea41d-d7cb-44a5-9982-8fc1d09221ac,Subset 1 - 2022_2023 PSES open dataset - with labels,36557874
+pc,9fb6e6a7-d0cf-44d9-b28e-c502928aa96c,Lake periphyton-Vuntut,6bacbe5c-5ee6-43ae-b119-03483342a132,Lake periphyton-Vuntut,43258
+wd-deo,9fbe6713-590d-4300-88ad-c2dc8b106860,Revenue growth rate of firms supported by WD programs,aff8bf55-6e4c-42de-96f2-69604742d1ee,Revenue Growth_e.csv,397
+dnd-mdn,9fbed581-4dd3-42c9-8244-59ee0b50bde8,National Defence Departmental Results Framework (DRF) ,b24da5c7-beb8-4514-ac2a-8350b9f3a023,National Defence Departmental Results Framework (DRF) ,28379
+cfia-acia,9fec4bf5-d1d9-45d5-9ace-5a5a4a12bf08,"Food Microbiology - Targeted Surveys - Final Report - Parasites in Imported Whole Fresh Sugar Snap and Snow Peas - April 1, 2016 to March 31, 2019",acaf4af6-96e2-476b-a041-07a88ec4586e,"Food Microbiology - Targeted Surveys - Final Report - Parasites in Imported Whole Fresh Sugar Snap and Snow Peas - April 1, 2016 to March 31, 2019",1193762
+pc,a0096ea6-6ce0-4007-b43e-9d535cd1a32c,Water Quality - Prince Albert,e43c3072-6bb8-435b-8b57-684a621b50e3,Water Quality - Prince Albert - Probe Data - 1,8005
+pc,a0096ea6-6ce0-4007-b43e-9d535cd1a32c,Water Quality - Prince Albert,cbe4734c-b609-47f5-ac40-45414d6b4d36,Water Quality - Prince Albert - Chemistry Data - 2,62523
+pc,a0096ea6-6ce0-4007-b43e-9d535cd1a32c,Water Quality - Prince Albert,41ab67bc-ac53-4919-b85c-6e4579ec52f0,Water Quality - Prince Albert - E.Coli Data - 3,252088
+pc,a0096ea6-6ce0-4007-b43e-9d535cd1a32c,Water Quality - Prince Albert,d6f95f5c-d22d-4570-b5b6-d0cebd911743,Water Quality - Prince Albert - Secchi Desk Data - 4,42992
+pc,a0096ea6-6ce0-4007-b43e-9d535cd1a32c,Water Quality - Prince Albert,ebdcc9d8-3ce0-4470-ae00-aa30a45e296a,Water Quality - Prince Albert - Discharge Data - 5,2201
+pc,a0096ea6-6ce0-4007-b43e-9d535cd1a32c,Water Quality - Prince Albert,6ecd37aa-02ab-433f-884b-2eefff0dd47c,Water Quality - Prince Albert - Chemistry Data Dictionary,329
+pc,a0096ea6-6ce0-4007-b43e-9d535cd1a32c,Water Quality - Prince Albert,8a44f203-8a1c-4d23-816c-9c02f6f86b62,Water Quality - Prince Albert - Data - 6,14076
+pc,a06b4479-5f57-416a-ad85-f246c0869f74,Tundra Non-Native Vegetation - Banff,e42550e5-45e2-466d-a0d0-8e8c3973d0d8,Tundra Non-Native Vegetation - Banff,1264
+pc,a06b4479-5f57-416a-ad85-f246c0869f74,Tundra Non-Native Vegetation - Banff,2d37768f-d99f-4004-81d7-f946cce0ba22,Tundra Non-Native Vegetation - Banff - Data Dictionary,351
+esdc-edsc,a0877b5b-07d0-4e44-b55d-743966eff37d,Canada Education Savings Grant (CESG) Payments by Province/Territory (in millions),fa457cec-89d8-4025-83ea-b85be5fa34cf,Canada Education Savings Grant (CESG) Payments by Province/Territory (in millions),2731
+esdc-edsc,a0877b5b-07d0-4e44-b55d-743966eff37d,Canada Education Savings Grant (CESG) Payments by Province/Territory (in millions),91f5947a-415d-4a51-bc69-179e545ee228,Canada Education Savings Grant (CESG) Payments by Province/Territory (in millions),2747
+pc,a147e177-7362-4cf8-b32e-6eddb8ab1d04,Sensitive Species Secure Habitat - Waterton Lakes - Forest,8a2fd9d2-2624-406c-baff-546be1f11018,Sensitive Species Secure Habitat - Waterton Lakes - percetn area data - 1 ,807
+pc,a1ee03ae-4a9d-4e75-9fc6-0a0fdd51a87f,Forest stands - Forillon,f84e0e61-7d1b-4295-bce9-6f29e550295c,Forillon_NP_Forest_Stands_1976-2018_Data1,635389
+pc,a1ee03ae-4a9d-4e75-9fc6-0a0fdd51a87f,Forest stands - Forillon,771bf72d-00a6-48b4-977b-0c6cd749d3db,Forillon_NP_Forest_Stands_2005-2018_Data2,104431
+pc,a1ee03ae-4a9d-4e75-9fc6-0a0fdd51a87f,Forest stands - Forillon,20e8bcb9-3299-4c8f-8deb-bf505814ee09,Forillon_NP_Forest_Stands_1976-2018_Data Dictionary,764
+pc,a207b89b-831e-4c56-9e4e-09de39246d6e,Growing Season Change - Kluane,1fe93fe1-0193-443b-ab63-639c9afdf648,Growing Season Change - Kluane,1590
+pc,a29dba8f-a791-4012-8c27-084ae7b76da9,Active Layer - Sirmilik,7ba2529b-a617-4e92-a3e5-04e2774e6fd8,Active Layer - Sirmilik - Circumpolar Active Layer Monitoring Grid Data,124796
+pc,a29dba8f-a791-4012-8c27-084ae7b76da9,Active Layer - Sirmilik,e7f34a0c-d726-47de-ac0a-4442866d36fe,Active Layer - Sirmilik - Thermal Characteristics of the Active Layer Data,6899158
+pc,a29dba8f-a791-4012-8c27-084ae7b76da9,Active Layer - Sirmilik,decc8e0a-39a1-4437-b155-264bab90ad63,Active Layer – Sirmilik – Characteristics of the Active Layer Data,1260
+pc,a2a478d5-926e-4398-9520-06f8eff48de2,Marsh Water Quality - Point Pelee,e22ed095-57fb-4a0d-ac14-837b448025f5,Marsh Water Quality - Point Pelee - Monitoring Data,106691
+pc,a2a478d5-926e-4398-9520-06f8eff48de2,Marsh Water Quality - Point Pelee,0e04f93a-c33e-4930-ad22-cf8f22ece039,Marsh Water Quality - Point Pelee - Monitoring Data Dictionary,296
+pc,a2b196e8-159b-46a7-b573-3269a20b250f,Yoho_NP_Alpine_Pika Haypile Surveys,fe470d8e-56ba-4114-bd80-931cb9b85388,Alpine Small Mammal Pika - Yoho,99715
+pc,a2da3fe4-1e61-46be-8e57-51258ed05498,Eelgrass Beds - Forillon,b3f8897d-dd66-4506-869f-27067a607c58,Situation eelgrass beds - Forillon - Data on fish (measurements) - 1,850712
+pc,a2da3fe4-1e61-46be-8e57-51258ed05498,Eelgrass Beds - Forillon,856f6c4f-20e1-41d5-806c-c2bbd6764792,Situation eelgrass beds - Forillon - Data on fish (counting) - 2,91066
+pc,a2da3fe4-1e61-46be-8e57-51258ed05498,Eelgrass Beds - Forillon,76137da0-6a21-4225-ae6a-8a1fa84955f1,Situation eelgrass beds - Forillon - Vegetation data (transects) - 3,12129
+pc,a2da3fe4-1e61-46be-8e57-51258ed05498,Eelgrass Beds - Forillon,f26941e6-ad26-4dca-8498-4a1965cafbc2,Situation eelgrass beds - Forillon - Vegetation data (quadrat) - 4,69118
+pc,a2da3fe4-1e61-46be-8e57-51258ed05498,Eelgrass Beds - Forillon,a539d8dc-a782-4243-9b3b-fa718da65dd4,Situation eelgrass beds - Forillon - Data dictionary,1232
+pc,a2da3fe4-1e61-46be-8e57-51258ed05498,Eelgrass Beds - Forillon,f848fb36-2d60-43b0-be99-2018bd951025,Situation eelgrass beds - Forillon - Species dictionary,2342
+cnsc-ccsn,a30a8985-8f92-49d1-85f0-8f5ad0b8f872,Administrative Monetary Penalties,dccce602-bd4e-4e50-937b-2bf9540b5418,Administrative Monetary Penalties (English),1425
+cnsc-ccsn,a30a8985-8f92-49d1-85f0-8f5ad0b8f872,Administrative Monetary Penalties,b38ff8ae-88fc-4587-aa26-6722224234a1,Administrative Monetary Penalties - Definitions (English),1742
+cnsc-ccsn,a30a8985-8f92-49d1-85f0-8f5ad0b8f872,Administrative Monetary Penalties,e538ba9b-3c41-4503-9454-c7d31ce5fda6,Administrative Monetary Penalties - Historical (English),3891
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,bbf91e2a-61bd-4987-9b70-7845a2b68ef0,Sources and Uses of the Budget Implementation vote by Department (2018-19),68126
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,3bafde71-8cb8-460e-93e2-691295221063,Public Accounts of Canada – Authorities and Expenditures by Vote,926828
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,27e54a33-3c39-42a9-8d58-46dd37c527e5,Public Accounts of Canada – Expenditures by Standard Object,1252531
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,f5622a6c-b623-43eb-a9d9-02901d10d901,Public Accounts of Canada – Expenditures by Standard Object,1415270
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,f942e312-df08-4f05-8fba-8b37b2a688db,Public Accounts of Canada – Transfer Payments,1659505
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,f516e998-2c05-490f-97f7-ab17e43c17d8,Public Accounts of Canada – Transfer Payments,1966637
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,f87c5f47-dd85-4c6f-b85e-2c59ccf8d84c,Estimates - Expenditure Budgetary Authorities by Vote,567777
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,89594b06-dd40-4e7e-b560-218c6ffe4cf1,Estimates - Expenditure Budgetary Authorities by Vote,720483
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,64774bc1-c90a-4ae2-a3ac-d9b50673a895,Departmental Plans and Departmental Results Reports – Expenditures and Full Time Equivalents (FTE) by Program and by Organization,3619022
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,0ea70f0a-7efd-492f-858c-8399150b7b5d,Departmental Plans and Departmental Results Reports – Expenditures and Full Time Equivalents (FTE) by Program and by Organization,4361310
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,09c15494-788e-4991-ad00-2bd905c4f225,Departmental Plans and Departmental Results Reports – Performance Information by Program and by Organization,31397199
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,2f98ef19-06a0-47a0-8e2a-29612cfada26,Departmental Plans and Departmental Results Reports – Performance information by Program and by Organization,39290343
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,7c131a87-7784-4208-8e5c-043451240d95,Inventory of Federal Organizations and Interests,240770
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,45069fe9-abe3-437f-97dd-3f64958bfa85,Inventory of Federal Organizations and Interests,286209
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,091091a5-1910-457a-9d05-3b4605ff9b24,Departmental Results Report – Actual performance information by Program and by Organization (2017-2018),3797413
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,aae6bf7f-1803-4264-a330-cbc9e671f522,Departmental Results Report – Actual performance information by Program and by Organization (2017-2018),4742407
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,51b784f5-5c5f-4b5a-aa7e-0d16ba00fc70,Departmental Results Reports – Actual Full Time Equivalents (FTE) by Program and by Organization (2017-2018),1511627
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,75f7464c-6ade-455c-b6e7-a9a8286002b9,Departmental Results Reports – Actual Full Time Equivalents (FTE) by Program and by Organization (2017-2018),1579254
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,25190cfc-b0d5-400a-bb37-408706149637,Departmental Results Reports – Expenditures by Program and by Organization (2017-2018),1591833
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,df4a38e1-0064-4553-b7ff-a48a9c477bf5,Departmental Results Reports – Expenditures by Program and by Organization (2017-2018),1717645
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,d0849787-3c1d-40e9-ae95-644a5cb41cc3,Sources and Uses of the Budget Implementation vote by Department (2019-20),1610162
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,aefee504-b570-4deb-9b7e-da219fb94ef1,Estimates - Statutory Forecasts,578901
+tbs-sct,a35cf382-690c-4221-a971-cf0fd189a46f,GC InfoBase - Open Datasets,c7306e2b-535f-45c0-86bb-d179e39d3c8c,Estimates - Statutory Forecasts,766310
+cfia-acia,a36ff706-d43f-46d6-9475-c4b468de86e6,Class I Recalls with Public Warnings listing Recalling Firm (2018-2021),a121d5f1-f067-43fa-a2b4-dfcc334c0911,Class I Recalls with Public Warnings listing Recalling Firm (2019-2020),37820
+tbs-sct,a3bfc930-d2ff-47c4-90bf-cbdff3dc4582,2020 Student Exit Survey (SES),13883ed4-f281-427c-9e2a-55b7a282feea,2020 Student Exit Survey,22812137
+pc,a3e15f08-0e32-4588-9e77-c19fcdd1b07f,Olive-Sided Flycatcher - Yoho,7fbea4cd-a163-48bd-a24e-8adaefcc8e6d,Olive-Sided Flycatcher - Yoho,676
+pc,a3e15f08-0e32-4588-9e77-c19fcdd1b07f,Olive-Sided Flycatcher - Yoho,f1cde372-1a14-4973-92c8-17f61f183660,Olive-Sided Flycatcher - Yoho - data dictionary,245
+pc,a417fe76-98f2-4f38-809b-3e466b6daf79,Blister rust infection - Jasper,76b9fa58-b0f9-423a-95e0-244eb176e944,Blister rust infection - Jasper,32277
+pc,a417fe76-98f2-4f38-809b-3e466b6daf79,Blister rust infection - Jasper,842f0086-cbbd-4fab-8550-4c6ed89d086c,Blister rust infection - Jasper - Data Dictionary,388
+pc,a4237e35-5cf1-49a9-9412-ee55d3511167,Invasive Plants - Gwaii Haanas,ebf5cd52-70ad-4f3b-9b2d-f0e9a1c36f5d,Invasive Plants,8359
+pc,a49166b2-307c-4a24-8067-8e4e56a89619,Stiff yellow flax- Georgian Bay Islands,45d8c89f-8bb2-4cbe-9c5e-3111c7fdc7c8,Stiff yellow flax- Georgian Bay Islands,13597
+cnsc-ccsn,a4d4b53b-143a-4d10-9ded-45abb164d239,"Lost, Stolen and Found Sealed Sources and Radiation Devices",b0fa1965-e5f2-4890-a1a9-04df93ac885e,"Lost, stolen, found sealed sources and radiation devices – 2008 to 2023 (English)",15469
+cnsc-ccsn,a4d4b53b-143a-4d10-9ded-45abb164d239,"Lost, Stolen and Found Sealed Sources and Radiation Devices",75fa107b-2b8e-49d3-b479-6f858240d740,"Lost, stolen, found sealed sources and radiation devices – 2008 to 2023 (French)",16459
+pc,a4fb5467-57b9-457b-86dc-7dd35596f448,Blanding's turtle - Kejimkujik,d8637571-e9c1-4640-9d29-90a49e0f003c,Blanding's Turtle - Kejimkujik - Summary Data,675
+dnd-mdn,a503f0de-b081-4b8f-ae69-651f8c95d676,Rank Appointment Insignia,7ae9597e-a610-4f4c-b620-e3f90be970ce,Rank Appointment Insignia,1605
+pc,a5b45372-1358-42b1-8efe-c039cab9ca50,Benthic Invertebrates - Cape Breton Highlands,61a1551d-08d1-4c3e-b1e4-c6bb10ae0242,Benthic Invertebrates - Cape Breton Highlands - Data Summary - 1,3263
+pc,a5b45372-1358-42b1-8efe-c039cab9ca50,Benthic Invertebrates - Cape Breton Highlands,dcd6fa35-1921-4540-a361-aa860466ca7f,Benthic Invertebrates - Cape Breton Highlands - Data Dictionary - 2,384
+pc,a67f2b8e-0322-4045-aadc-71b72d886526,Wetland Plant Bloom Period - Prince Edward Island,58d874c8-698d-404c-8635-1993bbe3f4da,Wetland Plant Bloom Period - Prince Edward Island - Data,58512
+pc,a67f2b8e-0322-4045-aadc-71b72d886526,Wetland Plant Bloom Period - Prince Edward Island,cae9a2bf-da31-468d-ba4f-734b48fcbff4,Wetland Plant Bloom Period - Prince Edward Island - Data Dictionary,1095
+pc,a69b310f-b644-4fb2-9cec-c80eff0eb956,Burrowing Owl Nest Attempts-Productivity - Grasslands,f40b72a6-1a2f-4137-974c-6d0d04b08866,Burrowing Owl Nest Attempts/Productivity - Grasslands,43959
+pc,a74c4e1b-3e8b-4ba0-acc4-ab9877dbba37, Forest Decay Rate - Terra Nova,56c1a433-1fdc-46c3-926c-c23a0643b88f, Forest Decay Rate - Terra Nova,42155
+pc,a7c3c7ce-a4fe-4c11-b665-079fc4d1ca6f,Permafrost - Wetlands -Vuntut,1b3ca999-15d0-4163-8523-ff86844ee5ba, Permafrost-Vuntut,3226
+pc,a8156b52-3ede-469e-af4d-0c2d9beacab5,Stream Water Temperature - Thousand Islands,93fa5cf4-1f98-4519-9ea6-bb4fef82ee96,Stream Water Temperature - Thousand Islands - Data,9077340
+pch,a8378e1a-47fa-4fea-b87c-d692ad406d9e,Number of visitors to travelling exhibitions supported by the Canada Travelling Exhibition Indemnification Program or the Museums Assistance Program,81d3de57-4a0a-43cb-99e9-ee9cfdee84d6,Heritage Access_EN,6767
+pc,a86ebc7b-83b1-4a9b-a935-84061f6cbd39,Contaminants in Colonial Waterbird Eggs - Wood Buffalo National Park,61bac685-3307-4127-9006-7b8f330a9dd2,Contaminants in Colonial Waterbird Eggs - Wood Buffalo,21112
+pc,a86ebc7b-83b1-4a9b-a935-84061f6cbd39,Contaminants in Colonial Waterbird Eggs - Wood Buffalo National Park,ec735a2c-b62b-462f-b3bd-73a1158d7f2c,Contaminants in Colonial Waterbird Eggs - Wood Buffalo - Data Dictionary,539
+pc,a889e2bc-4629-4977-871d-68010b1f231a,Lake Hydrology - Wapusk National Park,534a292b-d542-435b-9a0e-4a2c240c0a97,Lake Hydrology - Wapusk National Park,13790
+pc,a889e2bc-4629-4977-871d-68010b1f231a,Lake Hydrology - Wapusk National Park,a9f74a28-ad22-445d-a003-7dc215fc8586,Lake Hydrology - Wapusk National Park - Data Dictionary,4787
+pc,a8ed46b2-2a5c-4747-96bb-2df5213a06ca, Fish thermal stress - Terra Nova,fd214b24-2a3c-4617-8e42-62b31d1d4686, Stream Thermal Regimes - Terra Nova,2919703
+pc,a916dc1a-c655-4bb7-bd8d-472960c5c6df,Wood Frog Occupancy – Kluane,ef38d119-edf1-4592-8e71-8172f9836287,Wood Frog Occupancy - Kluane-2,974
+pc,a918ab0b-c015-444e-9628-edf5b5064208,Seabird Populations - Pacific Rim,fef7afe9-bdc7-4e7b-b194-1e05008f4ff7,Seabird Populations - Pacific Rim - Data,22818
+pc,a918ab0b-c015-444e-9628-edf5b5064208,Seabird Populations - Pacific Rim,6c1218d4-d678-4dd0-a39f-cd9cd6686660,Seabird Populations - Pacific Rim - Data Dictionary,1316
+cra-arc,a96af83b-213a-40e0-ace4-f8fb24fe05a4,Canada’s social security agreements with other countries,fd2e0039-f082-49c4-b72b-b0dd53078fda,Canada’s social security agreements with other countries,8175
+cra-arc,a96af83b-213a-40e0-ace4-f8fb24fe05a4,Canada’s social security agreements with other countries,0b86cb29-37dd-447e-a57b-7664d30d6235,Canada’s social security agreements with other countries,9168
+cfia-acia,aa007112-3acf-474a-8d46-855d96ba9925,Food Microbiology - Targeted Surveys - 2016 - 2018 Bacterial Pathogens in Baked Goods - Final Report,c512960b-f10d-4839-98b8-a9ca334a262b,Food Microbiology - Targeted Surveys - 2016 - 2018 Bacterial Pathogens in Baked Goods - Final Report,5192571
+pc,aa2fbc6c-17b6-4ccf-a20c-597ff5037a1b,Ecological Integrity of National Parks,17cd4a49-f9d3-4bf8-a442-2e92d3aba3d5,Ecological Integrity of National Parks 2021-2022,9574
+vac-acc,aa35aae4-348b-4d3f-92f1-efd0584f452e,2018–2019 Departmental Results Framework and Program Inventory,c99589a8-9953-40c8-b84a-7dece525173a,Office of the Veterans Ombudsman Complaints Received ,65674
+vac-acc,aa35aae4-348b-4d3f-92f1-efd0584f452e,2018–2019 Departmental Results Framework and Program Inventory,26ad5845-c308-48ca-8fc1-a775090d45f1,Canadian Virtual War Memorial Monthly page views,437
+vac-acc,aa35aae4-348b-4d3f-92f1-efd0584f452e,2018–2019 Departmental Results Framework and Program Inventory,256003ee-4381-46de-acc7-e106af4782c7,2018-2019 Departmental Results Framework,3856
+vac-acc,aa35aae4-348b-4d3f-92f1-efd0584f452e,2018–2019 Departmental Results Framework and Program Inventory,74a8b661-18ce-4bef-8a6c-04e5f9fe58a0,2018-2019 Program Inventory,7508
+cfia-acia,aa3de33f-e9b6-4386-bdcf-87d34a9d51f4,CFIA-Undeclared allergens and gluten in juice/nectar products - 2021-2022,c2b29163-e9ad-49d1-b656-2f18d6ccd2a7,CFIA-Undeclared allergens and gluten in juice/nectar products - 2021-2022,420484
+nrcan-rncan,aa426a7e-cf6b-4161-b84d-745820afe139,Cumulative effects of disturbances on soil nutrients: predominance of antagonistic short-term responses to the salvage logging of insect-killed stands,135ff275-9b84-482a-a571-e372797acf1b,Cumulative effects of disturbances on soil nutrients - Data,53731
+pc,ab0fffb5-98a1-471d-b736-c29f35aa0c8d,Adult Salmon  Health (Snorkel Surveys) - Cape Breton Highlands,d517799d-c35d-4afd-aef4-9a453c5b098a,Adult Salmon Health - Cape Breton Highlands - Data,40202
+pc,ab0fffb5-98a1-471d-b736-c29f35aa0c8d,Adult Salmon  Health (Snorkel Surveys) - Cape Breton Highlands,570728f9-77b7-4bec-aec0-a97a3e710aa0,Adult Salmon Health - Cape Breton Highlands - Survey Data,6023
+pc,ab0fffb5-98a1-471d-b736-c29f35aa0c8d,Adult Salmon  Health (Snorkel Surveys) - Cape Breton Highlands,bc07bfed-52ea-49da-9da2-a242cf3631f4,Adult Salmon Health - Cape Breton Highlands - Data Dictionary,1141
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,b3dbd574-81c0-44bb-a0e5-148b5b4a7fa4,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-12-01,
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,8fe9ae54-315a-4613-a30f-ba8136603856,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-11-01,2682717
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,c85a3a7d-a30b-4298-bfa0-9879008730d6,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-10-01,2673694
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,0674677f-8cac-4774-a523-cac5dc2a3670,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-09-01,2674547
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,913f9b5c-bea7-41d0-8c39-27a16e45a632,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-08-01,2666997
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,4837fd3e-1e3f-4d7e-9d48-c6d1b1e3b62b,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-07-01,2665647
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,62606671-a7c1-459a-843c-213ac9bef40a,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-06-01,2657384
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,6900fe34-8481-4105-bd5f-342da665858b,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-05-01,2653320
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,2e60bd65-5a37-490d-b6ff-0456cb24cff0,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-04-12,2681544
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,5d42f06e-2484-42e0-8681-4a360198202c,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-03-01,1526781
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,f500a899-54ca-4837-988c-056192caf1c6,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-02-01,1662733
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,c2c9dbd0-2721-4ce3-9aeb-c3d98e245ce8,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2024-01-01,1636171
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,89f31a82-16fc-4257-8da0-bd9eab99c4eb,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-12-01,1618660
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,2982aa71-67b3-49ca-a01d-4220795b13fc,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-11-01,1597718
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,3bfb41d4-a41e-475e-955c-0c8c1466e431,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-10-01,1445900
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,d4f6e6a5-f6eb-43bd-a267-752524661a51,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-09-01,1443103
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,718097af-1116-4403-a262-496a7e90c4c3,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-08-01,1416878
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,bf37257a-6538-4995-93ef-c90b9308cd37,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-07-01,1408997
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,e4992537-dc1d-4b24-8b4e-3f09cdd1902c,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-06-01,1406326
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,4d78663f-bc05-4e84-b69b-cc68449452d6,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-05-02,1439861
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,c546ea24-b0ee-481f-8afe-96a0d5742519, List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-04-03,1302233
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,6c112250-8ec4-4071-90a7-5e4705f1ae92,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-03-01,1300231
+psc-cfp,ab36a4ab-9b69-49b1-8be6-6faa3f0d0c67,List of post-secondary academic institutions and programs validated by the Public Service Commission,cbd25085-6f76-4ab7-9505-82b1e408477b,List of post-secondary academic institutions and programs validated by the Public Service Commission - 2023-02-01,1418342
+pc,abb2b5fb-245c-40c8-9779-923620a5adaf,Banff_NP_Forest_Winter Wildlife Corridor Tracking,d3351330-8a6e-4c5c-adeb-e3ab24858d4b,Winter Wildlife Corridors - Banff (Lake Louise),1581099
+pc,abb2b5fb-245c-40c8-9779-923620a5adaf,Banff_NP_Forest_Winter Wildlife Corridor Tracking,2c9f44d4-25f6-420d-a694-7934adbc9744,Winter Wildlife Corridors - Banff ,9137151
+pc,ac3df2e4-bf61-4b1d-a5b8-efb310bf50af,Bat Hibernacula and Maternity Roosts - Jasper,74986a60-8281-40cd-8bb1-878116ed309d,Bat Hibernacula and Maternity Roosts - Jasper,1852
+hc-sc,ac573724-2f77-4f75-a2f4-c416d79cf130,The 2008-2022 Total Diet Study Food Consumption Tables (2015 CCHS-Nutrition),56d65830-da14-4d83-92f9-af0beec5a70a,TDS food composite mapping descriptions - 2008-2022 TDS Consumption Table,13318
+hc-sc,ac573724-2f77-4f75-a2f4-c416d79cf130,The 2008-2022 Total Diet Study Food Consumption Tables (2015 CCHS-Nutrition),5c9eec7f-03f6-40fb-ad21-d74d5b0f6af6,TDS food composite mapping descriptions - 2008-2022 TDS Consumption Table,17952
+hc-sc,ac573724-2f77-4f75-a2f4-c416d79cf130,The 2008-2022 Total Diet Study Food Consumption Tables (2015 CCHS-Nutrition),41ebf95a-947a-4446-8122-429f8586b127,Daily intake per person - 2008-2022 TDS Consumption Table,1615775
+hc-sc,ac573724-2f77-4f75-a2f4-c416d79cf130,The 2008-2022 Total Diet Study Food Consumption Tables (2015 CCHS-Nutrition),d8b1f727-3e87-48f9-add1-09c25fd7eb35,Daily intake per person - 2008-2022 TDS Consumption Table,1819619
+hc-sc,ac573724-2f77-4f75-a2f4-c416d79cf130,The 2008-2022 Total Diet Study Food Consumption Tables (2015 CCHS-Nutrition),7375b102-fd1c-4be3-b96e-2fdd5dc6f961, Daily intake per kilogram bodyweight - 2008-2022 TDS Consumption Table,1500600
+hc-sc,ac573724-2f77-4f75-a2f4-c416d79cf130,The 2008-2022 Total Diet Study Food Consumption Tables (2015 CCHS-Nutrition),e2037453-dc84-4586-8e29-f719089a8666,Daily intake per kilogram bodyweight - 2008-2022 TDS Consumption Table,1707051
+hc-sc,ac573724-2f77-4f75-a2f4-c416d79cf130,The 2008-2022 Total Diet Study Food Consumption Tables (2015 CCHS-Nutrition),9963dfe7-f212-4833-98ab-060b72e8f9b6,Bodyweights - 2008-2022 TDS Consumption Table,1572
+hc-sc,ac573724-2f77-4f75-a2f4-c416d79cf130,The 2008-2022 Total Diet Study Food Consumption Tables (2015 CCHS-Nutrition),55209e76-7645-4af8-9953-bbc8ebe46f02,Bodyweights - 2008-2022 TDS Consumption Table,1756
+pc,acf24f12-9f40-4bbe-b87f-54e0fa3ab23b,Seedling Regeneration - Thousand Islands,b209eefd-b4ad-4869-8557-1e0beb1c9c66,Seedling Regeneration - Thousand Islands - Data,196434
+pc,acf24f12-9f40-4bbe-b87f-54e0fa3ab23b,Seedling Regeneration - Thousand Islands,af02f7f0-7b1d-47be-bee5-1c483dacc37d,Seedling Regeneration - Thousand Islands - Data Dictionary,3164
+tbs-sct,ad654070-505c-425c-baa9-94c8271e1c85,ATIP Online Request Service analytics,4722e5d6-ff15-4a3c-9893-3ec4717d1022,Key Metrics Report - 2019-01,1052
+tbs-sct,ad654070-505c-425c-baa9-94c8271e1c85,ATIP Online Request Service analytics,e71914f6-b027-422c-a59d-a7038cc58ff3,Unique Visitors Report - 2019-01,696
+tbs-sct,ad654070-505c-425c-baa9-94c8271e1c85,ATIP Online Request Service analytics,ef63218d-74ee-47de-9374-025b3b5fbdc2,Exit Page Unique Visitors Report - 2019-01,600
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,d16e10ea-77bf-4db8-bdb5-adc709e6cada,2024 Wages,18613523
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,ff45366b-1c17-4862-8325-f6e7797c7c56,2023 Wages,10026256
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,8d49f430-6dfd-4122-a18d-b0868381f0e6,2022 Wages,17203951
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,74a2d523-9760-415e-b722-8a237ab649db,2021 Wages,17473959
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,c2db20d5-92bc-40d2-aa9f-6c868badc0b9,2020 Wages,17571645
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,3abae67c-78a7-4e06-b2b2-fe9870100381,2019 Wages,17353526
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,a8cbef28-5252-45df-8773-ef96c65a61ac,2018 Wages ,17812513
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,c8a9c949-c21a-49f0-bfa8-c2d943cf4d29,2017 Wages ,17738332
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,2a1fe964-7d3f-4337-a454-ef346db5609a,2016 Wages,18127713
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,7215dbfa-8e5c-417c-8c95-0a916eaedcc1,2015 Wages,18720079
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,ff3ea4e1-896f-4fa2-8754-c8a9f83c89b0,2014 Wages,18421378
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,c4bcd5c4-9b04-4bb8-8067-f5484a69e592,2013 Wages,16580624
+esdc-edsc,adad580f-76b0-4502-bd05-20c125de9116,Wages ,5fd8d9f2-008f-41a6-a200-1a0253a4d9b5,2012 Wages,17232021
+pc,ae99dc53-f4db-4e33-93af-722f8ffebc66,Land Area Classification (Forest Area) - Cape Breton Highlands,d39fa5cc-be0e-4375-b982-df508c775d95,Land Area Classification/Forest Area - Cape Breton Highlands - Land Classification Summary - 1,1046
+pc,ae99dc53-f4db-4e33-93af-722f8ffebc66,Land Area Classification (Forest Area) - Cape Breton Highlands,da3b7d23-5d45-4892-9c8a-ed2171f53cd9,Land Area Classification/Forest Area - Cape Breton Highlands - Boreal Forest Cover Summary - 2,331
+pc,ae99dc53-f4db-4e33-93af-722f8ffebc66,Land Area Classification (Forest Area) - Cape Breton Highlands,9557ae0c-2cea-4448-8b49-0cc97b28495b,Land Area Classification/Forest Area - Cape Breton Highlands - Data Dictionary - 3,1964
+pc,aea61195-065b-4848-aba3-fab32c33e54c,Lake Fish Index - Waterton Lakes - Freshwater,88ec57f4-fe6b-4567-aa67-87462400a0d2,Lake Fish Index - Waterton Lakes - Score data - 1,5433
+pc,aea61195-065b-4848-aba3-fab32c33e54c,Lake Fish Index - Waterton Lakes - Freshwater,f81a8656-dc64-4c95-931c-ea762544a104,Lake Fish Index - Waterton Lakes - Score data dictionary - 2,5319
+pc,aea7f785-e0c6-464f-9181-f0c3ad41ab1b,Exotic and Invasive Aquatic Plant Abundance - Georgian Bay Islands,0ffbfb11-ed2c-419c-a2a9-31b371240c0d,Exotic and Invasive Aquatic Plant Abundance - Georgian Bay Islands,669358
+pc,aea7f785-e0c6-464f-9181-f0c3ad41ab1b,Exotic and Invasive Aquatic Plant Abundance - Georgian Bay Islands,d69db820-e398-4a4c-ba01-52fbe7bbbc9f,Exotic and Invasive Aquatic Plant Abundance - Georgian Bay Islands,934
+pc,aeab61c8-95af-4eb6-b66d-b6d6dd981605,Bison populations - Elk Island,11507d40-aa22-4c65-a80e-65b583bba2e5,Bison populations - Elk Island,50279
+pc,aeab61c8-95af-4eb6-b66d-b6d6dd981605,Bison populations - Elk Island,0abf6752-fbd5-4a13-b610-9113ac5828f8,Bison populations - Elk Island - Data dictionary,4714
+pc,aee8f259-3743-4e6f-addf-bbae4bae8a7e,Canadian Aquatic Biomonitoring Network - Banff,9713b155-c070-4608-97d7-9cec02b57698,Canadian Aquatic Biomonitoring Network - Banff,2468
+pc,aee8f259-3743-4e6f-addf-bbae4bae8a7e,Canadian Aquatic Biomonitoring Network - Banff,88e53a42-2346-4b58-b1e1-af2c472a3b6b,Canadian Aquatic Biomonitoring Network - Banff - Data Dictionary,475
+pc,aefdaf04-48f6-4c81-920a-beef5680f8b0,Common Tern Colony - Kouchibouguac,98b1b159-572f-4c0d-b4c9-597b1be9cc4a,Common Tern Colony - Kouchibouguac - Data,894
+pc,aefdaf04-48f6-4c81-920a-beef5680f8b0,Common Tern Colony - Kouchibouguac,67fbbedc-e226-4237-86e7-0da4868525c5,Common Tern Colony - Kouchibouguac - Metadata,412
+pc,af2e62d2-776e-4955-a9b8-b22161514641, Stream Invertebrate Taxa Richness - Terra Nova,16e3695d-bf71-491a-8e82-d81e62f609af, Stream Invertebrate Taxa Richness - Terra Nova,567351
+dnd-mdn,afa9c0a7-7cf5-4a7a-b034-cf1eb4705d9d,High Priority Requisition Supply Records for the West Coast Royal Canadian Navy Fleet,5a2f75c0-9561-4c1c-9d95-900e232115c8,High Priority Requisition Supply Records for the West Coast Royal Canadian Navy Fleet,3347530
+dnd-mdn,afa9c0a7-7cf5-4a7a-b034-cf1eb4705d9d,High Priority Requisition Supply Records for the West Coast Royal Canadian Navy Fleet,9270d5d8-c7bd-4cbe-91c1-3a0679306d1e,High Priority Requisition Supply Records for the West Coast Royal Canadian Navy Fleet,1756
+dnd-mdn,afa9c0a7-7cf5-4a7a-b034-cf1eb4705d9d,High Priority Requisition Supply Records for the West Coast Royal Canadian Navy Fleet,e7684a0d-2931-4fd1-8ee8-c222088fe5d3,High Priority Requisition Supply Records for the West Coast Canadian Navy Fleet,1580
+dnd-mdn,b0488a2e-e784-4b2d-aa88-3a4829b1d708,Defence Forms Catalogue Listing,062e1ac9-62a6-40fb-90e6-2ab684a90295,Defence Forms Catalogue,357894
+pc,b061fdeb-26af-4e8a-9ed4-076dfdad53ec,Subalpine - Gwaii Haanas,d2792bc9-2de3-4ade-beaf-124e22d6e28c,Subalpine - Gwaii Haanas,149104
+pc,b061fdeb-26af-4e8a-9ed4-076dfdad53ec,Subalpine - Gwaii Haanas,40e866f9-7e3b-4e84-bbff-66cc87767d0b,Subalpine - Gwaii Haanas - data dictionary,277
+pc,b0d13c82-7eee-4358-a86b-b73c73f519f2,Wildlife Mortality Data - Kootenay,5ab88277-f9bf-46fa-bbfb-6881f2a36533,Wildlife Mortality Data - Kootenay,35046
+pc,b0d13c82-7eee-4358-a86b-b73c73f519f2,Wildlife Mortality Data - Kootenay,849f8e27-8693-4e4b-b4c7-5a68863b5268,Wildlife Mortality Data - Kootenay - data dictionary,1645
+pc,b10f3d90-fdd2-4177-b390-d635d0f12b11,Moose Survey Counts - Kluane,6aac2728-7d46-4d34-8dce-ac3e3beddc15,Moose survey Count - Kluane,1787
+cfia-acia,b14b083f-f8eb-4907-957a-37b686321e76,Food Microbiology - Targeted Surveys - 2016 - 2018 Bacterial Pathogens in Chocolate-based Confectionaries - Final Report,e7354aa3-068b-432e-93f7-26e8a95b52fd,Food Microbiology - Targeted Surveys - 2016 - 2018 Bacterial Pathogens in Chocolate-based Confectionaries - Final Report,3014355
+tbs-sct,b15ee8d7-2ac0-4656-8330-6c60d085cda8,GC InfoBase – Departmental Plans and Results Reports,02929919-d9ab-494e-8fce-012119b479ff,Expenditures and Full Time Equivalents (FTE) by Program and by Organization,1585668
+tbs-sct,b15ee8d7-2ac0-4656-8330-6c60d085cda8,GC InfoBase – Departmental Plans and Results Reports,19aba95f-3db9-4d20-a0f4-43d88a7e67cf,Expenditures and Full Time Equivalents (FTE) by Program and by Organization,1910229
+tbs-sct,b15ee8d7-2ac0-4656-8330-6c60d085cda8,GC InfoBase – Departmental Plans and Results Reports,069fba50-2a06-414e-9db8-800d3e8a0953,Performance Information by Program and by Organization,16683780
+tbs-sct,b15ee8d7-2ac0-4656-8330-6c60d085cda8,GC InfoBase – Departmental Plans and Results Reports,b771d9c3-5b9c-42ee-b838-72342a1c0ee3,Performance Information by Program and by Organization,20892458
+hc-sc,b166b1c1-0313-4706-8cca-f464f6fc7086,Food Source Contribution Table (2015 CCHS Nutrition),aa0fe0a9-5f0f-4252-9a42-f0589a6eb01f,Updated - FSCT Dataset - Foods and Recipes (2015 CCHS Nutrition),4535625
+hc-sc,b166b1c1-0313-4706-8cca-f464f6fc7086,Food Source Contribution Table (2015 CCHS Nutrition),0b52577d-1a8c-45b8-ab70-acf7adf1c55f, Updated - FSCT Dataset - Foods and Recipes (2015 CCHS Nutrition),5570880
+hc-sc,b166b1c1-0313-4706-8cca-f464f6fc7086,Food Source Contribution Table (2015 CCHS Nutrition),7ae4273d-cccf-4c8c-b796-43b58bef452c,Updated - FSCT Dataset - Foods and Ingredients (2015 CCHS Nutrition),4082872
+hc-sc,b166b1c1-0313-4706-8cca-f464f6fc7086,Food Source Contribution Table (2015 CCHS Nutrition),935572f3-bbb0-420a-b4ac-58dddb7177db,Updated - FSCT Dataset - Foods and Ingredients (2015 CCHS Nutrition),4992047
+hc-sc,b166b1c1-0313-4706-8cca-f464f6fc7086,Food Source Contribution Table (2015 CCHS Nutrition),592655e8-a5de-43fa-b3d5-90016bf212b8,FSCT Food Group List - Foods and Recipes (2015 CCHS Nutrition),21718
+hc-sc,b166b1c1-0313-4706-8cca-f464f6fc7086,Food Source Contribution Table (2015 CCHS Nutrition),9b903a6a-98fb-47aa-8e28-09f8dbb515c0, FSCT Food Group List - Foods and Recipes (2015 CCHS Nutrition),27972
+hc-sc,b166b1c1-0313-4706-8cca-f464f6fc7086,Food Source Contribution Table (2015 CCHS Nutrition),0ee33ee3-30c2-4a5c-9216-7a6200c6fe1a, FSCT Food Group List - Foods and Ingredients (2015 CCHS Nutrition),18682
+hc-sc,b166b1c1-0313-4706-8cca-f464f6fc7086,Food Source Contribution Table (2015 CCHS Nutrition),7a84422b-07c2-48d0-888f-c63278af2ee9,FSCT Food Group List - Foods and Ingredients (2015 CCHS Nutrition),23745
+pc,b16ef29c-a71d-4693-a2f1-8c92cc2ca438,Moose_situation - Forillon,90ee75d9-3c3d-4a95-97be-4c5c3a684e45,Moose_situation - Forillon - Data dictionary ,764
+pc,b16ef29c-a71d-4693-a2f1-8c92cc2ca438,Moose_situation - Forillon,96dffede-b468-4e52-8155-a65f31936f56,Moose situation - Forillon - Data,66990
+pc,b186b764-f9d6-4104-b495-589ba765f81b,Athabasca glacier mass balance - Jasper,0a7c1d36-6793-4080-aa9b-3b650dc19ac3,Athabasca glacier mass balance - Jasper,18043
+pc,b186b764-f9d6-4104-b495-589ba765f81b,Athabasca glacier mass balance - Jasper,ba19267d-4a0a-4996-80ac-464b4c9668a0,Athabasca glacier mass balance - Jasper - Data Dictionary,338
+pc,b26161dd-82a4-4ee0-834d-dc94f71178b8,Forest_Eider_Mingan,4c716446-18fc-4d10-9263-0363890f544a,Eider nest abundance in forest-Mingan-Number of nest data,294684
+pc,b26161dd-82a4-4ee0-834d-dc94f71178b8,Forest_Eider_Mingan,c5c8efa9-924e-4996-9404-8dca4a2e210e,Eider nest abundance in forest-Mingan-Number of nest data_Data_dictionary,3224
+pc,b277cd9b-25a2-455a-8f57-f0d27fb12f5c,Mountain Goat Survey Count - Kluane,48863a23-c691-4ee4-9161-55322e802063,Mountain Goat Survey Count - Kluane,608
+cra-arc,b2acb3be-c720-4329-a8c0-d4d36c8db61e,2022 List of charities,abd0d652-de97-44bb-884a-a8a196890174,Private/Public Foundations,
+cra-arc,b2acb3be-c720-4329-a8c0-d4d36c8db61e,2022 List of charities,b889b268-a1a2-49ed-b0e1-6715385a844f,Activities outside Canada – Countries where program was carried,
+cra-arc,b2acb3be-c720-4329-a8c0-d4d36c8db61e,2022 List of charities,b1732cca-1bb2-4465-9792-558591e7c0fc,Activities outside Canada – Details on financial,
+cra-arc,b2acb3be-c720-4329-a8c0-d4d36c8db61e,2022 List of charities,fd631f06-e775-46eb-8f90-320279a2e23b,Activities outside Canada - Exported goods,
+cra-arc,b2acb3be-c720-4329-a8c0-d4d36c8db61e,2022 List of charities,6439f41e-fa8d-474d-ab07-a5721a066274,Compensation,
+cra-arc,b2acb3be-c720-4329-a8c0-d4d36c8db61e,2022 List of charities,bdd44a8c-6c54-4ab2-9059-ca30c5ad6e20,Political Activities / Public Policy and Development Activities – Description,
+cra-arc,b2acb3be-c720-4329-a8c0-d4d36c8db61e,2022 List of charities,ff9e83a8-0f4e-495c-a6d0-76f398a0a7d3,Political Activities – Funding,
+cra-arc,b2acb3be-c720-4329-a8c0-d4d36c8db61e,2022 List of charities,8dee0c0e-0599-4eeb-8eb9-acd29ace7c06,Political Activities – Resources,
+pc,b2bbc213-eb55-4ac3-8f08-7a13a56888dc,Collared Pika - Nahanni,dcd0ed9b-61fb-4a8c-9ad9-682abefd61ff,Collared Pika - Nahanni - Data,83211
+pc,b2bbc213-eb55-4ac3-8f08-7a13a56888dc,Collared Pika - Nahanni,47091287-ebe0-41ad-a482-16eafd84b6d6,Collared Pika - Nahanni - Data dictionary,2312
+pc,b3518b3d-ea93-4d6e-9ad0-d13165f12d15,Wetland Pitcher Plants - Cape Breton Highlands,f6c252fd-484d-4829-91bb-f968f3131f7c,Wetland Pitcher Plants - Cape Breton Highlands - Data,216891
+pc,b3518b3d-ea93-4d6e-9ad0-d13165f12d15,Wetland Pitcher Plants - Cape Breton Highlands,07fd2d1b-7cab-4586-82ed-6f1300ff3531,Wetland Pitcher Plants - Cape Breton Highlands - Site Data,5403
+pc,b3518b3d-ea93-4d6e-9ad0-d13165f12d15,Wetland Pitcher Plants - Cape Breton Highlands,864541f4-e956-426b-b957-17e2d169a34f,Wetland Pitcher Plants - Cape Breton Highlands - Data Dictionary,1805
+dnd-mdn,b373c407-e1a3-465b-8398-8940b4004552,Canadian Cadet Organizations- Qualifications and Awards,2427b0a3-68ca-4ed0-8768-073f9ad37388,Qualifications and Awards,27467638
+pc,b45c8ed8-bfc4-4a13-a9e2-c19a3e71c2c5,Bird Diversity and Abundance - Prince Albert,c016a285-bbf7-463b-a60d-07ae76385f4b,Bird Diversity and Abundance - Prince Albert - Data - 1,3213508
+pc,b45c8ed8-bfc4-4a13-a9e2-c19a3e71c2c5,Bird Diversity and Abundance - Prince Albert,8af63e4f-4b33-4469-a074-07272ae1f9ff,Bird Diversity and Abundance - Prince Albert - Data Dictionary,22667
+dnd-mdn,b4687b77-7536-4ab1-b732-d8df2a361410,Percentage of civilian employees who describe the workplace as psychologically healthy,bc34f231-29ea-4ce7-bc24-a67f6d26a1db,% of civilian employees who describe the workplace as psychologically healthy,2057
+elections,b545fe25-5cf5-4488-9923-b5c2ebeeb8cc,"Turnout by Age, Gender and Province, GE38–GE44 ",73586e35-290d-431c-94ba-5cf8a97c4ae5,"Turnout by Age, Gender and Province, GE38–GE44",329326
+pc,b5662fca-2082-428e-a9c3-3234822bbecd,Active Layer - Auyuittuq,18f57da8-053d-47aa-a5d7-74daf9f56d15,Active Layer - Auyuittuq - Circumpolar Active Layer Monitoring Grid Data,36726
+pc,b5662fca-2082-428e-a9c3-3234822bbecd,Active Layer - Auyuittuq,fe8837b8-4944-45d7-97fc-8cde88c7e246,Active Layer - Auyuittuq - Thermal Characteristics of the Active Layer Data,3151686
+pc,b5662fca-2082-428e-a9c3-3234822bbecd,Active Layer - Auyuittuq,09f6c7ad-84f0-4764-a45e-0f35cd599fbd,Active Layer - Auyuittuq - Circumpolar Active Layer Monitoring Grid Data Dictionary,340
+pc,b5662fca-2082-428e-a9c3-3234822bbecd,Active Layer - Auyuittuq,3bc0af2c-d418-4014-add2-a0952ce4cd9c,Active Layer – Auyuittuq – Characteristics of the Active Layer Data ,479
+pc,b56c200d-cefa-4f9e-babf-c04f7102fc3d,Forest Plant Bloom Period - Prince Edward Island,abc011b5-1a62-4be0-b155-a372986d9fc4,Forest Plant Bloom Period - Prince Edward Island,58512
+pc,b56c200d-cefa-4f9e-babf-c04f7102fc3d,Forest Plant Bloom Period - Prince Edward Island,e24f6553-8ef1-4c76-b4a1-4510649fd8ca,Forest Plant Bloom Period - Prince Edward Island - Data Dictionary,912
+cfia-acia,b581a6e0-2bfc-448f-a8b8-a98939f5cf6b,CFIA Undeclared Gluten in Candy - 2014-2015,01563f66-79b3-493c-904f-eee3f3bf3141,CFIA Undeclared Gluten in Candy - 2014-2015,109350
+pc,b5d0d787-d4a3-46f7-a40d-7e7ae88771fd,Growing degree days-Vuntut,c46b6d66-8f41-4a7e-811e-5c44b94786f9,Growing degree days-Vuntut,166
+pc,b6720d64-1d3e-4fdc-8254-193478a95e32,Beavers - Active Lodges/Dams - Terra Nova,71ac5268-f170-4884-bb56-82a0ca345b9e,Beavers - Active Lodges/Dams - Terra Nova,20614
+pc,b6720d64-1d3e-4fdc-8254-193478a95e32,Beavers - Active Lodges/Dams - Terra Nova,7968212a-6e61-4df6-aff7-89fe92321abf,Beavers - Active Lodges/Dams - Data Dictionary,819
+pc,b6a903fd-f964-4d31-b7f5-77e7187ac87c,Terrestrial Invasive Plants - Fundy,a768a8b2-0eb2-4c44-a6c7-4a72dcde9d39,Terrestrial Invasive Plants - Fundy,12527
+pc,b6a903fd-f964-4d31-b7f5-77e7187ac87c,Terrestrial Invasive Plants - Fundy,6dfc1ba5-eeed-4cd2-bc1d-22dc819ced77,Terrestrial Invasive Plants - Fundy - data dictionary,534
+hc-sc,b7730f98-4441-44f6-afc0-5434a67de2ab,BC sector study VOC dataset,67b3ad65-e5f1-4523-94de-aeb0ea584855,BC Sector Study VOC dataset,7526
+hc-sc,b7730f98-4441-44f6-afc0-5434a67de2ab,BC sector study VOC dataset,5f4a6d2e-8210-4448-b5da-3d91dbd1348c,BC Sector Study VOC dataset,7640
+ssc-spc,b7989d7b-de56-43b7-92c3-9a1305b9b395,Percentage of cloud brokering requests fulfilled within established service level standards,0ae48987-36ac-4ede-b609-b74350a0eda9,Percentage of cloud brokering requests fulfilled within established service level standards,1620
+ssc-spc,b7989d7b-de56-43b7-92c3-9a1305b9b395,Percentage of cloud brokering requests fulfilled within established service level standards,6bac4c94-f3d4-46d9-9d18-8b88c345398b,Percentage of cloud brokering requests fulfilled within established service level standards,1745
+pc,b7e77a61-cb7c-4adb-8d8d-9dce045cd4ef,Whitebark Pine Seedling assessment - Glacier,dfef7e52-14b1-4c6c-af40-95d6a6dbae82,Whitebark Pine Seedling assessment - Glacier,47506
+pc,b7e77a61-cb7c-4adb-8d8d-9dce045cd4ef,Whitebark Pine Seedling assessment - Glacier,4ff0a472-fa06-4eeb-81b5-164931bcec06,Whitebark Pine Seedling assessment - Glacier - Data Dictionary,1327
+csec-cstc,b7e8c894-53bd-4a62-8c05-6726921abb98,2021-2022 Canadian Centre for Cyber Security - Contact Centre Statistics ,5f29af03-e522-4a09-9299-eb5bcfc47efd,CSV EN/FR,2173
+cfia-acia,b82370ef-13c8-4179-b937-520b1e1359c9,CFIA Undeclared Gluten in Gluten-Free Bakery Mixes - 2017-2018,8333f559-b83c-461c-8cbb-1545f9b54dbf,CFIA Undeclared Gluten in Gluten-Free Bakery Mixes - 2017-2018,48018
+pc,b825f0fa-4ff6-4eed-b22c-411e2a10d937,Coastal Greater Yellowlegs Abundance - Terra Nova,7e614e6d-3b9b-4ea7-9c7f-34e8e89ac0fc,Coastal Greater Yellowlegs Abundance - Terra Nova,2097
+cfia-acia,b82c0bc3-1f5a-403b-a944-3c89dfcdae1e,Food Microbiology - Targeted Surveys - 2017 - 2018 Bacterial Pathogens in Edible Insects - Final Report,303cd496-c72a-4ef3-959d-4a5d75d0545e,Food Microbiology - Targeted Surveys - 2017 - 2018 Bacterial Pathogens in Edible Insects - Final Report,30961
+pc,b90fce08-2425-4a50-ba31-2975b5d9eb58,Coastal_Rare plants_Mingan_Abundance_Data,ab007ba6-2307-495c-aca8-06dd64e3e552,Abundance of rare plants (focal) in the coastal ecosystem- Mingan-Abundance data-2,48115
+pc,b90fce08-2425-4a50-ba31-2975b5d9eb58,Coastal_Rare plants_Mingan_Abundance_Data,f7bb43f8-8bd7-420c-9de6-3c4f221a557d,Abundance of rare plants (colony) in the coastal ecosystem- Mingan-Abundance data-1_Data_dictionary,2317
+pc,b90fce08-2425-4a50-ba31-2975b5d9eb58,Coastal_Rare plants_Mingan_Abundance_Data,fdaa5db8-971b-4667-a1cf-2f0628ff3a75,Abundance of rare plants (focal) in the coastal ecosystem- Mingan-Abundance data-2_Data_dictionary,1522
+esdc-edsc,b9f150d7-d55d-445c-994e-269f1a807080,Elder Abuse Advertising Campaign Evaluation Tool (ACET) Methodology Report,fed0e0c9-16b7-4bfc-8c47-5c2ea8764348,2009 Elder Abuse Advertising Campaign Evaluation Tool - DATASET,299574
+pc,b9f21e91-d34d-4730-8195-edf051121e9d,Beaver abundance & distribution - Elk Island,cb670925-7e88-4b80-b61a-5fe746d0a4a3,Beaver abundance & distribution - Elk Island,2108173
+pc,b9f21e91-d34d-4730-8195-edf051121e9d,Beaver abundance & distribution - Elk Island,a848bad5-9e00-411c-96ed-a2c79aec114c,Beaver abundance & distribution - Elk Island - Data dictionary,5322
+tbs-sct,b9f51ef4-4605-4ef2-8231-62a2edda1b54,Proactive Disclosure - Hospitality Expenses,7b301f1a-2a7a-48bd-9ea9-e0ac4a5313ed,Proactive Disclosure - Hospitality Expenses,24474109
+tbs-sct,b9f51ef4-4605-4ef2-8231-62a2edda1b54,Proactive Disclosure - Hospitality Expenses,36a3b6cc-4f45-4081-8dbd-2340ca487041,Proactive Disclosure - Hospitality Nothing to Report,420450
+pc,ba31c525-b49d-4eb6-b99f-fe08372fda18,"Percentage of historical and archaeological collection, cultural landscapes and archaeological sites in Parks Canada’s care that are safeguarded",9d566840-08a8-4a57-9fa1-8f2a2859894f,"Percentage of historical and archaeological collection, cultural landscapes and archaeological sites in Parks Canada’s care that are safeguarded 2021-2022",1091
+pc,ba8f8a4a-3c4f-4cd5-b1f9-7e4dd8c21f28,Coastal Wetland Water Quality - Fathom Five,c8b9ec2a-6528-49a9-b9b0-b4b3dda94d3b,Coastal Wetland Water Quality - Fathom Five,37041
+pc,ba8f8a4a-3c4f-4cd5-b1f9-7e4dd8c21f28,Coastal Wetland Water Quality - Fathom Five,48d2df24-1358-4a93-a72e-23eaa71cdf67,Coastal Wetland Water Quality - Fathom Five - Data Dictonary,1066
+cra-arc,ba9e7b19-729e-4229-ade7-a2a7653be6c2,Canada Child Benefit (CCB) Statistics by Federal Electoral District – 2019-2020 Benefit Year,e3ad5efc-8101-4830-97bc-3155ff847983,Explanatory Notes,972
+cra-arc,ba9e7b19-729e-4229-ade7-a2a7653be6c2,Canada Child Benefit (CCB) Statistics by Federal Electoral District – 2019-2020 Benefit Year,4191ac65-9168-4aca-a741-e076cafc6611,Explanatory Notes,1122
+pc,bab87330-9592-4b92-8169-6f81355efb06,Water quality situation - La Mauricie,309e51d1-5ac1-4842-a8d5-8ef3130839ad,Water quality situation - Data 1,278607
+pc,bab87330-9592-4b92-8169-6f81355efb06,Water quality situation - La Mauricie,82241916-3fac-4fbd-97bb-7c83fadebf5a,Water quality situation - Data 2,2279
+pc,bab87330-9592-4b92-8169-6f81355efb06,Water quality situation - La Mauricie,29670afa-9e24-46e3-90d4-3f798ed38f5f,Water quality situation - Data 3,15785
+pc,bab87330-9592-4b92-8169-6f81355efb06,Water quality situation - La Mauricie,9336a56a-dd81-4068-b213-d351540113bf,Water quality situation - Data Dictionary,5985
+pc,bb424128-f71b-4767-86ce-7b3b1649c1df,Black Oystercatcher - Gwaii Haanas,39c867e5-c925-4e38-907e-b118a5024df7,Black Oystercatcher - Gwaii Haanas,1270
+pc,bb4fe053-5770-42e5-b424-2e5a51811ea1,Amphibians - Jasper,1dc8369c-c354-4a8c-a6cd-6fd137212c70,Amphibians - Jasper,10038
+cer-rec,bba41250-261a-4f3b-9ce8-db44d9a0f725,Canada’s Energy Future 2020: Energy Supply and Demand Projections to 2050,80117e7a-35d4-43c8-bdb4-672f73f9a0ab,coal-2020-data-dictionary,2355
+pc,bc4707a3-e172-4315-8126-6c08e9378ca2,Avian diversity & abundance - Elk Island,1bb9731d-bae8-4dbc-90e2-b8864daf4313,Avian diversity & abundance - Elk Island,3202904
+pc,bc4707a3-e172-4315-8126-6c08e9378ca2,Avian diversity & abundance - Elk Island,6994476f-958c-4af0-a723-2c602d8175f6,Avian diversity & abundance - Elk Island - Data dictionary,3047
+pc,bc4707a3-e172-4315-8126-6c08e9378ca2,Avian diversity & abundance - Elk Island,48445896-843e-4869-94a6-b07e79b8fe40,Avian diversity & abundance - Elk Island Species List,16055
+pc,bc96c05e-801d-411b-8bbd-7926cadc02be,Prescribed Fire Targets - Glacier,d6d7bc2e-da9a-4dc3-ad07-2388ac3541d0,Prescribed Fire Targets - Glacier,873
+pc,bc96c05e-801d-411b-8bbd-7926cadc02be,Prescribed Fire Targets - Glacier,6de008a4-4394-47a5-82b2-89f75528ebed,Prescribed Fire Targets - Glacier - Data Dictionary,984
+pc,bcc90275-e139-4c2a-99ee-1c52e04a856f,Parks Canada attendance 2020_21 ,32334e09-a041-4a5a-a2e5-70c26485d586,Parks Canada attendance 2020_21,5568
+esdc-edsc,bcf66dd4-a8c0-495c-9ed4-814bb917510c,Cumulative Number of Canada Education Savings Grant (CESG) Beneficiaries by Age Group,23398428-d958-4909-b3ee-98d3ae2c4d82,Cumulative Number of Canada Education Savings Grant (CESG) Beneficiaries by Age Group,748
+esdc-edsc,bcf66dd4-a8c0-495c-9ed4-814bb917510c,Cumulative Number of Canada Education Savings Grant (CESG) Beneficiaries by Age Group,d0b6352e-2212-4166-bdf8-ab004917b25b,Cumulative Number of Canada Education Savings Grant (CESG) Beneficiaries by Age Group,746
+cra-arc,bd2c9156-2bbe-43c9-b5fe-513e28b7af4e,2009 List of charities,dc979a1a-9ae1-4ea0-823e-beae49c073cd,Charities Businesses Directors/Officers,53948706
+cra-arc,bd2c9156-2bbe-43c9-b5fe-513e28b7af4e,2009 List of charities,3beb7a99-9f7d-4cfa-b4d3-6a31607fc6c2,Financial data,18653258
+cra-arc,bd2c9156-2bbe-43c9-b5fe-513e28b7af4e,2009 List of charities,35f0bfa0-a9c2-49fa-9abe-7a1a291a228a,General information,16379191
+cra-arc,bd2c9156-2bbe-43c9-b5fe-513e28b7af4e,2009 List of charities,81149154-ae46-4a14-b145-6058f38bbfb7,Identification,12096328
+cra-arc,bd2c9156-2bbe-43c9-b5fe-513e28b7af4e,2009 List of charities,271d6726-7432-4371-b86e-16b5bf1cc62a,Charitable Programs,29897963
+cra-arc,bd2c9156-2bbe-43c9-b5fe-513e28b7af4e,2009 List of charities,ced99663-5f61-429f-ace7-a086a185b848,Qualified donees,23762031
+cra-arc,bd2c9156-2bbe-43c9-b5fe-513e28b7af4e,2009 List of charities,0bff3962-f660-49a4-8676-0356255f976c,Private/Public Foundations,3061247
+cra-arc,bd2c9156-2bbe-43c9-b5fe-513e28b7af4e,2009 List of charities,945d49dc-4040-4371-8384-bc474a5d39a4,Activities outside Canada – Countries where program was carried,399502
+pc,bd60ee47-f45b-420b-ac44-b8e60c8d1664,Benthic Invertebrate Communities - Forillon,9b124bdf-317d-4dd1-8aca-7ef54c813608,Benthic invertebrate communities - Forillon - Data on the parameter values,6913
+cfia-acia,bd7557a0-d1a2-464d-8999-92493d279930,CFIA-Undeclared allergens and gluten in soup and broth - 2020-2021,5ad5db2d-c262-4aea-bccd-509768171adb,CFIA-Undeclared allergens and gluten in soup and broth - 2020-2021,425763
+pc,bd890807-c128-4217-a4d0-35243e657ca3,Forest Birds - Thousand Islands,638195e1-7292-4228-89dd-9d7cd076d2e0,Forest Birds - Thousand Islands - Data,105372
+pc,bd890807-c128-4217-a4d0-35243e657ca3,Forest Birds - Thousand Islands,df4f52a9-2796-4aca-869c-a556a4459572,Forest Birds - Thousand Islands - Data Dictionary,7537
+pc,be55758d-1ed2-4a81-b5f2-d45615c7fb0f,Browse Pressure - Terra Nova,f7c2aa4d-a707-489e-9529-8b268c5996e9,Browse Pressure - Terra Nova - Data Dictionary,7957
+pc,bee0d45f-76a9-49ec-aabc-28d73e172fcc,Pond Angling Stress - Terra Nova,71daa859-287a-48c1-a657-2bdcd4547b54,Pond Angling Stress - Terra Nova,851037
+pc,bee0d45f-76a9-49ec-aabc-28d73e172fcc,Pond Angling Stress - Terra Nova,67fcc58c-249a-48ef-adff-edada3fd2c44,Pond Angling Stress-2,48546
+pc,bee0d45f-76a9-49ec-aabc-28d73e172fcc,Pond Angling Stress - Terra Nova,69251307-249b-413c-bcf7-508a10871a7a,Pond Angling Stress - Terra Nova - Data Dictionary,638
+tc,bf00b7f4-e370-46b7-94e4-0bdedc98531b,Canadian Register of Large Vessels,0b5a739d-b01e-43df-8757-7fc1453baec5,Canadian Register of Large Vessels ,12875757
+tc,bf00b7f4-e370-46b7-94e4-0bdedc98531b,Canadian Register of Large Vessels,83925e69-8679-4cc5-bcb4-3c34fb154fed,Canadian Register of Large Vessels ,13195573
+irb-cisr,bf181c11-8c67-4b98-a002-c0f016b2e43c,Open Dataset Request 833195 - RPD decisions from 1997-2021 by outcome and province of claimant,ba8d99b9-2f76-4b9a-b179-172fbe3101f5,Open Dataset Request 833195 ENG - RPD decisions from 1997-2021 by outcome and province of claimant,24579
+pc,bf34b83f-a9fa-47b2-96b0-2ad73c779cce,Goose Aquatic Assessment - Wapusk National Park,7b22fb8a-6aea-48c1-ab8e-0f893378db0e,Goose Aquatic Assessment - Wapusk National Park,11279
+pc,bf34b83f-a9fa-47b2-96b0-2ad73c779cce,Goose Aquatic Assessment - Wapusk National Park,161d7409-0824-49ff-a93a-6adbd20a0aad,Goose Aquatic Assessment - Wapusk National Park - Data Dictionary,4665
+cfia-acia,bfac4a9d-ba2f-433a-8425-9b2fc7689d72,2009-2010 Aflatoxin in Dried Figs and Dried Dates,8339ffec-f854-430c-b3c8-4718e18ed4b2,2009-2010 Aflatoxin in Dried Figs and Dried Dates,60259
+ssc-spc,bfbcc5b7-c9e4-4852-bba8-b1e26f149954,Customer Satisfaction Feedback Initiative – Service Questionnaire Results,320b8365-ac05-4311-876d-ec2962d1a514,Customer Satisfaction Feedback Initiative – Service Questionnaire Results,694360
+ssc-spc,bfbcc5b7-c9e4-4852-bba8-b1e26f149954,Customer Satisfaction Feedback Initiative – Service Questionnaire Results,c9e28240-e9de-49a5-9f47-11befc131761,Customer Satisfaction Feedback Initiative – Service Questionnaire Results,834598
+pc,bfde394f-f01c-4243-be06-4aa1b2ec07ca,Invasive plants - Jasper,0f3180a3-4144-4b9f-8b5c-785e1d94707d,Invasive plants - Jasper,359361
+pc,c0f26195-c452-4432-ae43-669807dac505,Forest Salamander Abundance - Cape Breton Highlands,b4b09c4f-a206-4607-beae-69086f46762d,Forest Salamander Abundance - Cape Breton Highlands - Data,474949
+pc,c0f26195-c452-4432-ae43-669807dac505,Forest Salamander Abundance - Cape Breton Highlands,09144a36-e605-431a-b562-e90c00d4d252,Forest Salamander Abundance - Cape Breton Highlands - Site Data,819
+pc,c0f26195-c452-4432-ae43-669807dac505,Forest Salamander Abundance - Cape Breton Highlands,4a19dced-2748-46c3-a5e3-5fe9c7d8f6a2,Forest Salamander Abundance - Cape Breton Highlands - Data Dictionary,2481
+ssc-spc,c115e246-3f60-4b0c-8788-ff897e59c9af,Legacy Data Centres,c849b326-1674-4ce0-9f62-5e9f651676fa,Legacy Data Centres,1712186
+ssc-spc,c115e246-3f60-4b0c-8788-ff897e59c9af,Legacy Data Centres,784f271e-80a4-4520-bef8-9e2a13e53193,Legacy Data Centres,2009721
+dnd-mdn,c19f1fbb-b74d-4902-831d-40cd00b0003d,Crude Canadian Armed Forces (CAF) Regular Force Male Suicide Rates,82046008-578f-4604-9cb9-7b68d5540aed,Crude Canadian Armed Forces (CAF) Regular Force Male Suicide Rates,904
+pc,c1e80817-b234-43b3-92d0-73e327d112ac,Situation of medium-size carnivores - La Mauricie,8b0bbc6e-4b32-49e0-af32-5192090d116f,Situation of medium-size carnivores - Data,1701
+pc,c1e80817-b234-43b3-92d0-73e327d112ac,Situation of medium-size carnivores - La Mauricie,e65e5edb-df7b-477a-9da4-ea108613a3dd,Situation of medium-size carnivores - Data Dictionary,270
+pc,c1f2be4f-d182-4e79-b902-3fac3cc65747,Forest Composition – Kluane,f97f1952-cd88-4b85-9e3d-57924bc86c85,Forest Composition - Kluane-1,284
+pc,c1f2be4f-d182-4e79-b902-3fac3cc65747,Forest Composition – Kluane,f1966ef6-2363-4259-83dc-d7e63c782aaa,Forest Composition - Kluane-3,463
+pc,c1f2be4f-d182-4e79-b902-3fac3cc65747,Forest Composition – Kluane,5afc8b6f-d760-40da-b078-81b4417898ce,Forest Composition - Kluane - Data Dictionary,331
+pc,c1f9aadf-ea83-4a32-a04e-720b5cf0437d,Nearshore Ice - Prince Edward Island,e953a82e-ad5a-4287-9a8d-830464473419,Nearshore Ice - Prince Edward Island,654
+opc-cpvp,c22e29fd-cb94-4a62-b4cb-5079848dddc8,2023-24 Survey of Canadian businesses on privacy-related issues,663811d3-9d70-4074-8d40-c5ba71dd5816,2023-24 Survey of Businesses on privacy-related issues_Dataset,198634
+pc,c294b53d-52e7-4cf9-8b13-cffded2b31cb,Amphibian Occupancy - Waterton Lakes - Freshwater,30f2216c-7bce-44a1-988f-a85f2784c303,Amphibian Occupancy - Waterton Lakes - Visual Encounter Survey Data 1,79193
+pc,c294b53d-52e7-4cf9-8b13-cffded2b31cb,Amphibian Occupancy - Waterton Lakes - Freshwater,c4c634c6-ba50-4013-bdf6-d431303993d3,Amphibian Occupancy - Waterton Lakes - Visual Encounter Survey Data Dictionary - 2,1422
+tbs-sct,c2e19896-fe09-432b-85cf-4ab7788a0407,Suggested Dataset Submissions,412116a4-59b6-4ce0-af3a-7ee1c6704b22,Suggest a Dataset,230246
+pc,c32225ed-108f-437a-be32-12ec5efde1e4,Forest Songbirds - Kouchibouguac,85d663df-b1fe-441f-b284-726feebf1daf,Forest Songbirds - Kouchibouguac - Data,2025401
+pc,c32225ed-108f-437a-be32-12ec5efde1e4,Forest Songbirds - Kouchibouguac,494c699a-5daa-4474-80b2-0aadd84f3a55,Forest Songbirds - Kouchibouguac - Metadata,3350
+pc,c32225ed-108f-437a-be32-12ec5efde1e4,Forest Songbirds - Kouchibouguac,87d23619-b28f-44ad-84f3-87834aee0e8f,Forest Songbirds - Kouchibouguac - Data Dictionnary,12315
+pc,c3313d3c-7212-4f71-b0cc-77f4a4c17df8,Songbird Community - Pacific Rim,6777f1f1-aab8-4da5-b1b8-74b1ecd1f124,Songbird Community - Pacific Rim - Data,178757
+pc,c3313d3c-7212-4f71-b0cc-77f4a4c17df8,Songbird Community - Pacific Rim,51e3a8d9-c190-41e1-8df1-0a945ef9ec45,Songbird Community - Pacific Rim - Data Dictionary,3239
+pc,c36ecbc1-d2a0-4a97-ad5f-6e4dccd17a8c,Canadian Aquatic Biomonitoring Network - Glacier,73497f63-f040-4702-9584-c6669d786c2b,Canadian Aquatic Biomonitoring Network - Glacier,1452
+pc,c36ecbc1-d2a0-4a97-ad5f-6e4dccd17a8c,Canadian Aquatic Biomonitoring Network - Glacier,c71bbe79-7de3-4b77-bd67-485178376f87,Canadian Aquatic Biomonitoring Network - Glacier - Data Dictionary,584
+pc,c387c782-fad0-4058-9900-79a6c5f9d7ea,Forest Dynamics - Kouchibouguac,a12f2d0a-0399-4fd1-806b-6119b0c91b56,Forest Dynamics - Kouchibouguac - Stand Data - 1,300562
+pc,c387c782-fad0-4058-9900-79a6c5f9d7ea,Forest Dynamics - Kouchibouguac,fd43d355-bac8-4a97-a3fe-bb411d96cbc5,Forest Dynamics - Kouchibouguac - Recruitment Data - 2,33795
+pc,c387c782-fad0-4058-9900-79a6c5f9d7ea,Forest Dynamics - Kouchibouguac,373d273f-1c7d-4ca2-80cf-5cbe000ec74b,Forest Dynamics - Kouchibouguac - Recruitment Data Dictionnary - 2,1126
+pc,c3b178a5-cdc6-4802-8895-1bd44644d37b,Stream Benthic Invertebrates Stress - Thousand Islands,70f61ab3-ac32-4519-ad5b-b11d5b428858,Stream Benthic Invertebrates Stress - Thousand Islands,1839632
+pc,c3b178a5-cdc6-4802-8895-1bd44644d37b,Stream Benthic Invertebrates Stress - Thousand Islands,32b6e3a9-3c60-4cde-a34b-c277ef871dce,Stream Benthic Invertebrates Stress - Thousand Islands - Data Dictionary,12558
+nrcan-rncan,c3d02090-959d-4762-a5ff-77339c7414b6,NTSC TOPIC - Tree Seed Traits,9c41870c-c7dd-427b-9fc0-f231995b90a2,Traits data,1248991
+nrcan-rncan,c3d02090-959d-4762-a5ff-77339c7414b6,NTSC TOPIC - Tree Seed Traits,bdc21d3e-b33d-4fe8-89b3-5372d5da13d8,Data dictionary,19932
+esdc-edsc,c488ca75-b78a-492b-9dfe-5490aebb3e31,Occupational Injuries in the Canadian Federal Jurisdiction by Industry Sector: 2008-2021,ff2f8d3a-a583-47a2-92f0-7a0252de5e46,Occupational Injuries in the Canadian Federal Jurisdiction by Industry Sector: 2008-2021,36107
+tbs-sct,c4c5c7f1-bfa6-4ff6-b4a0-c164cb2060f7,Open Data Portal Catalogue,312a65c5-d0bc-4445-8a24-95b2690cc62b,datasets metadata,111598627
+tbs-sct,c4c5c7f1-bfa6-4ff6-b4a0-c164cb2060f7,Open Data Portal Catalogue,3c911562-c541-463f-8cd4-490182cd57f9,Resources Metadata,106142869
+tbs-sct,c4c5c7f1-bfa6-4ff6-b4a0-c164cb2060f7,Open Data Portal Catalogue,a79f7297-9b20-427a-be79-d286daa92412,resource views metadata,837890
+tbs-sct,c4c5c7f1-bfa6-4ff6-b4a0-c164cb2060f7,Open Data Portal Catalogue,3733106d-74f1-428e-beda-cad530b473cf,datastore fields metadata,5762034
+tbs-sct,c4c5c7f1-bfa6-4ff6-b4a0-c164cb2060f7,Open Data Portal Catalogue,09c51a72-e803-4050-8b8f-165809bccf05,Data Package Fields ,10197
+pc,c522329f-5d67-487b-a419-1db204821725,Alpine Terrestrial Birds - Glacier,8f179106-597e-4ff0-97b1-31fe73d4898e,Alpine Terrestrial Birds - Glacier,92619
+pc,c522329f-5d67-487b-a419-1db204821725,Alpine Terrestrial Birds - Glacier,7f789522-f597-49c3-ab2b-a8261402ed0e,Alpine Terrestrial Birds - Glacier - Data Dictionary,1743
+pc,c54269eb-e45d-4c84-87ab-0a2927655b64,Songbirds - Gwaii Haanas,e2f8e5fa-dc9b-4b9b-8225-c5933af690a0,Songbirds - Gwaii Haanas,16352
+esdc-edsc,c5de7c99-0ace-4540-987f-23ca245c8457,Yearly Canada Education Savings Grant (CESG) Beneficiaries and Payments by Forward Sortation Area ,e16b4baa-269e-4bbf-843a-f88ee5899e13,Yearly Canada Education Savings Grant (CESG) Beneficiaries and Payments by Forward Sortation Area ,98689
+esdc-edsc,c5de7c99-0ace-4540-987f-23ca245c8457,Yearly Canada Education Savings Grant (CESG) Beneficiaries and Payments by Forward Sortation Area ,5d8997c4-0703-4c88-935a-cb82b25c3912,Yearly Canada Education Savings Grant (CESG) Beneficiaries and Payments by Forward Sortation Area ,98706
+pc,c6140f52-c144-449c-a518-88564149087d,Porcupine Caribou Herd-population size-Vuntut,d6966b4e-9f22-44fc-bdac-cbf2f2a5800c,Porcupine Caribou Herd-population size-Vuntut,1429
+pc,c6aaeadb-94b4-4c95-baf3-808b59d806cb,Red-breasted Merganser - Kouchibouguac,336eed12-5e1f-47a6-a5e4-5d5d2d738537,Red Breasted Merganser - Kouchibouguac - Data,516
+cfia-acia,c6b38054-b1d3-4408-869f-60afeffc5f18,CFIA-Undeclared Allergens and Gluten in Sauces and Salad Dressings - 2020-2021,cdcc819e-5a99-4d20-a8fc-8a00d4e86ad6,CFIA-Undeclared Allergens and Gluten in Sauces and Salad Dressings - 2020-2021,422143
+pc,c733971a-b612-496c-b692-ab94a8c87a10,Invasive Species Composite - Prince Edward Island,2186f61b-ec74-4ca6-ae64-0d8fd3d56e0d,Invasive Species Composite - Prince Edward Island - Garlic Mustard Data - 1,362953
+pc,c733971a-b612-496c-b692-ab94a8c87a10,Invasive Species Composite - Prince Edward Island,b5099cae-95c7-4df8-a842-8e914ca46727,Invasive Species Composite - Prince Edward Island - Glossy Buckthorn Data - 2,285333
+pc,c733971a-b612-496c-b692-ab94a8c87a10,Invasive Species Composite - Prince Edward Island,6a16080f-2405-4718-a897-6b100d493f01,Invasive Species Composite - Prince Edward Island - Gypsy Moth Data - 3,2910
+pc,c733971a-b612-496c-b692-ab94a8c87a10,Invasive Species Composite - Prince Edward Island,e0458b1a-3d4f-4e2b-ad77-2d4d0af66402,Invasive Species Composite - Prince Edward Island - Japanese Knotweed Data - 4,99867
+pc,c733971a-b612-496c-b692-ab94a8c87a10,Invasive Species Composite - Prince Edward Island,4d0ac08c-f16f-4ff5-88d0-d7dd77788ddc,Invasive Species Composite - Prince Edward Island - Scotch Pine Data - 5,60420
+pc,c733971a-b612-496c-b692-ab94a8c87a10,Invasive Species Composite - Prince Edward Island,32c05372-4274-45ea-977b-0687931f0d1e,Invasive Species Composite - Prince Edward Island - Data Dictionary,3824
+pc,c7864225-4384-4f16-97c7-bf21ffbb7b4d,Western Toad - Gwaii Haanas,0c79489a-2344-4c6e-9923-89181d4d092a,Western Toad - Gwaii Haanas,1225
+pc,c88eccf1-cd95-4ced-a9ef-05bf4f974ede,Dune Integrity - Prince Edward Island,6d9a98de-19a2-467f-b7a3-a9ff0d724ec8,Dune Integrity - Prince Edward Island - Dune Movement Data - 1,457561
+pc,c88eccf1-cd95-4ced-a9ef-05bf4f974ede,Dune Integrity - Prince Edward Island,4a3925e9-3ef0-43ac-9e70-187daf8703d0,Dune Integrity - Prince Edward Island - Trail Crossings Data - 2,4518
+pc,c88eccf1-cd95-4ced-a9ef-05bf4f974ede,Dune Integrity - Prince Edward Island,5f680578-d3f7-43e3-a4a8-9ff437317d4d,Dune Integrity - Prince Edward Island - Data Dictionary - 3,4823
+tbs-sct,c922e515-1ac1-442c-8b10-f26e798bab18,Government of Canada classifications,b9a2dfb9-7c26-4ff3-893e-03c0832348df,Reference Data ,40887
+pc,c9500582-1155-453d-b441-6ae623206493,Whitebark Pine Stand Assesments - Glacier,cd64663d-3551-46d7-965b-7952c4c7aa09,Whitebark Pine Stand Assesments - Glacier,2429
+pc,c9500582-1155-453d-b441-6ae623206493,Whitebark Pine Stand Assesments - Glacier,62c201dd-b73c-42d7-8712-06d62df0ed42,Whitebark Pine Stand Assesments - Glacier - Data Dictionary,333
+pc,cabaac7b-bab9-4b93-a7bf-3a14b8205879,Amphibian occupancy - Elk Island,abd19fdb-e9e5-494d-8cb5-3ebcd2b59151,Amphibian occupancy - Elk Island,52701
+pc,cabaac7b-bab9-4b93-a7bf-3a14b8205879,Amphibian occupancy - Elk Island,d641e4d2-9a22-455b-86d3-69221eaf07db,Amphibian occupancy - Elk Island - Data dictionary,3962
+dfatd-maecd,cac6fd9f-594a-4bcd-bf17-10295812d4c5,"Data Reference Standard on Countries, Territories and Geographic areas ",bdb33e8c-53ef-4bae-9493-35f343191c02,"Data Reference Standard on Countries, Territories and Geographic areas",70953
+cfia-acia,cc2f654c-ea4a-4de2-871b-e8fe6ecb6862,"Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens and Indicators in Ready-to-Eat Powdered Infant Cereal and Children's Breakfast Cereal - April 1, 2018 to March 31, 2020",a70915ad-296b-496e-b4fe-0573c331eabe,Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens and Indicators in Ready-to-Eat Powdered Infant Cereal and Children's Breakfast Cereal - 2019-2020,185567
+cfia-acia,cc2f654c-ea4a-4de2-871b-e8fe6ecb6862,"Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens and Indicators in Ready-to-Eat Powdered Infant Cereal and Children's Breakfast Cereal - April 1, 2018 to March 31, 2020",f6b95ef5-0f6a-4cdb-94da-0373e72e3fe8,Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens and Indicators in Ready-to-Eat Powdered Infant Cereal and Children's Breakfast Cereal - 2018,63520
+pc,cc3d7dc6-db8a-4bd8-85e5-4244452cbf7a,Invasive non-native plants - Waterton Lakes - Grasslands,36e9b2b0-a37c-48b6-8e87-e2ca453c3d2c,Invasive non-native plants - Waterton Lakes - cover data - 1,1694683
+pc,cc3d7dc6-db8a-4bd8-85e5-4244452cbf7a,Invasive non-native plants - Waterton Lakes - Grasslands,9f8b5cc7-40b6-4573-a40c-2394e3ec91d2,Invasive non-native plants - Waterton Lakes - cover data dictionary - 2,5405
+pc,cc865663-1998-449e-b7fc-40dc84a18bf8,Banff_NP_Freshwater_Amphibian Visual Surveys,623c1cb4-7b34-46ed-851e-132d09504fad,Amphibians - Banff,118256
+pc,cc865663-1998-449e-b7fc-40dc84a18bf8,Banff_NP_Freshwater_Amphibian Visual Surveys,c632e922-3cb7-48fa-a94a-57266de4170e,Amphibians - Banff - Data Dictionary,2908
+tbs-sct,cd8fad92-b276-4250-972f-2d6c40ca04fa,Data reference standard on Canadian Provinces and Territories,4cb827a6-a313-4d97-a66b-26fe23984931,Reference data on Canadian Provinces and Territories,731
+pc,ce777149-3cb9-4ac2-a133-0924fef16c6e,Odonata - Prince Edward Island,d372ff1b-f43a-4c67-8635-b8b202e5d46b,Odonata - Prince Edward Island,263250
+pc,ce777149-3cb9-4ac2-a133-0924fef16c6e,Odonata - Prince Edward Island,65ef3dde-da1d-41c1-8843-a25db1139aca,Odonata - Prince Edward Island - Data Dictionary,3844
+csec-cstc,cf203591-87bd-4400-adcd-17df54b6c59d,2012-2023 Employment tenure distribution for the Communications Security Establishment,66fc7b9f-370b-41e6-b049-f4b9ed468340,CSV EN/FR,385
+pc,cf20bcd2-ea82-48a8-8fd0-c66e0478d303,Human-Wildlife Interactions -Jasper,f0bac9f4-3bc3-4727-9419-4a224676c52e,Human-Wildlife Interactions -Jasper,1027557
+pc,cf20bcd2-ea82-48a8-8fd0-c66e0478d303,Human-Wildlife Interactions -Jasper,86a40391-1f4f-49e3-9171-ac3ef82bc568,Human-Wildlife Interactions -Jasper - data dictionary,13254
+cnsc-ccsn,cf5e2d1e-5d92-4c19-9713-c5c88b8c6944,"Application to amend the Power Reactor Operating Licence of the Pickering Nuclear Generating Station (NGS) to operate units 5–8 to December 31, 2026 - Information and Reports",1161bd03-15ee-4bf0-9cbe-9562425c9ba0,"Document titles which are of importance to Ontario Power Generations (OPG)'s Application to amend the Power Reactor Operating Licence of the Pickering Nuclear Generating Station (NGS) to operate units 5–8 to December 31, 2026",10102
+pc,d0ee0d3c-77dc-4926-bfd7-4ad7b22037fc,Carnivore situation - Forillon,808f2f5d-a547-42c3-bdae-764ba5a5ba93,Canivore_situation - Forillon - Data,17929
+pc,d0ee0d3c-77dc-4926-bfd7-4ad7b22037fc,Carnivore situation - Forillon,6f4347a3-51c2-4280-a186-dcba552720fb,Carnivore_situation - Forillon - Data dictionary ,2888
+tc,d0f54727-6c0b-4e5a-aa04-ea1463cf9f4c,Grade Crossings Inventory ,a53fda5b-134f-449d-a639-9b896065fc21,Grade Crossings Inventory,4000479
+tc,d0f54727-6c0b-4e5a-aa04-ea1463cf9f4c,Grade Crossings Inventory ,78ea83eb-8a4a-4a5c-a3d1-0e47e228e5a5,Grade Crossings Inventory,3968049
+pc,d1016933-0eb6-4381-9eb5-317c5de052dd,Area disturbed by Fire - Waterton Lakes - Grasslands,2a24dd77-472f-4f76-9b00-e970428c397a,Area Disturbed by Fire - Waterton Lakes - Grasslands data - 1,3099
+pc,d1016933-0eb6-4381-9eb5-317c5de052dd,Area disturbed by Fire - Waterton Lakes - Grasslands,0b9c9e14-3c1b-476c-8603-78847e60394f,Area Disturbed by Fire - Waterton Lakes - Grasslands data dictionary - 2,1222
+pc,d1f21795-c1b1-4647-b280-0d541ab4d25a,Elk - Waterton Lakes - Grasslands,b7d618f9-2f01-4384-9114-5cd453f38563,Elk - Waterton Lakes - air survey data - 1,1468
+pc,d1f21795-c1b1-4647-b280-0d541ab4d25a,Elk - Waterton Lakes - Grasslands,27a9c745-5f6e-4f5b-8ef5-32abeab854b7,Elk - Waterton Lakes - ground counts data - 2,807
+pc,d1f21795-c1b1-4647-b280-0d541ab4d25a,Elk - Waterton Lakes - Grasslands,3c1c3afa-1af4-4cbe-b746-fc117494ced3,Elk - Waterton Lakes - historic data - 3,2940
+pc,d1f21795-c1b1-4647-b280-0d541ab4d25a,Elk - Waterton Lakes - Grasslands,e6d49730-6e52-4f7f-8138-fc147c736edc,Elk - Waterton Lakes - data dictionary - 4,585
+pc,d22111cd-1482-428e-8ad2-d55a73dce962,Breeding seabirds - Gwaii Haanas,46c81ab2-465b-46ae-8b57-3a89b825b717,Breeding seabirds - Gwaii Haanas,2575
+tbs-sct,d2d72709-e4bf-412d-a1bd-8c726d19393e,2018-2020 National Action Plan on Open Government Reporting Data,0da69302-fbf9-4026-9e71-656744046acc,Quartery tracker for National Action Plan on Open Government ,946397
+pc,d502eb76-067c-46a0-8deb-18e9cda9f693,Water Quality Simplified - Tuktut ,7fa24814-de94-4110-b37f-b87664f6bb73,"Water Quality Simplified - Tuktut -Nutrients, Physicals ,and Major Ions - 2015-2017 - data - 1",5639
+pc,d502eb76-067c-46a0-8deb-18e9cda9f693,Water Quality Simplified - Tuktut ,8d706047-0b9c-4226-8570-c9ed71b8a3df,Water Quality Simplified - Tuktut -Metals - 2015-2017 - data - 2,10066
+pc,d502eb76-067c-46a0-8deb-18e9cda9f693,Water Quality Simplified - Tuktut ,888ecc53-0a1f-4795-b579-0ba2891f2269,Water Quality Simplified - Tuktut - 2015-2017 - data dictionary,1060
+ssc-spc,d521eba3-8534-4a15-b31a-aca14e10c296, External Credential Management Service Availability,0470eeb1-69d0-4e54-83b9-862789bf4840,External Credential Management Service Availability,20572
+ssc-spc,d521eba3-8534-4a15-b31a-aca14e10c296, External Credential Management Service Availability,493defe5-07e0-4373-a91e-64cdc5d7546a,External Credential Management Service Availability,22132
+ssc-spc,d521eba3-8534-4a15-b31a-aca14e10c296, External Credential Management Service Availability,fe28342b-04c8-4e91-902f-3bdcbb77a09b,GCKEY,2924
+ssc-spc,d521eba3-8534-4a15-b31a-aca14e10c296, External Credential Management Service Availability,22e5d219-ee44-494d-8a8d-ec6115428338,GCKEY,4239
+ssc-spc,d521eba3-8534-4a15-b31a-aca14e10c296, External Credential Management Service Availability,4f402fcd-c5c2-4848-a80b-958fd85913f4,SecureKey Concierge,4150
+ssc-spc,d521eba3-8534-4a15-b31a-aca14e10c296, External Credential Management Service Availability,29344fb4-8980-477e-bc13-d84b9e85160a,SecureKey Concierge,5657
+pc,d5a2f0bd-03a2-4a8d-9e88-591ffe4c292e,Stream Temperature - Bruce Peninsula,64bfa38f-b084-478b-8f84-d86fe9f78592,Stream Temperature - Bruce Peninsula,84067
+pc,d5a2f0bd-03a2-4a8d-9e88-591ffe4c292e,Stream Temperature - Bruce Peninsula,2839d5c2-569e-4b95-ae28-9816cb2b1ef0,Stream Temperature - Bruce Peninsula - Data Dictionary ,607
+pc,d5a75b00-f93f-4e42-9672-85a6a77d4ea3,Black-Tailed Prairie Dog Area of Occurrence (SAR),fd4a4f5c-d357-4c1c-9f8c-bbec7d9ad1c2,Black-Tailed Prairie Dog Area of Occurrence (SAR),4424
+pc,d5fd45b9-7c70-4339-a68b-e60d7cbf42e8,Wildlife Crossing Structures - Banff,bd8c589f-4023-4f37-8e07-d948a8fcb6d0,Wildlife Crossing Structures - Banff,13073
+pc,d602fbd0-0159-414e-9ea5-72c3127340d9,Elk roadside surveys - Jasper,c71d0424-1bab-4eeb-ae6d-719a5a5eda56,Elk roadside surveys - Jasper,586
+pc,d6120900-86ac-4806-9b54-083cd4acaed8,Tundra_Eider_Mingan_Number of nest_Data,5da4d4b1-9bd1-4d44-a4ad-c7990f7ca95e,Eider number of nest in the tundra- Mingan-Number of nest data,438409
+pc,d6120900-86ac-4806-9b54-083cd4acaed8,Tundra_Eider_Mingan_Number of nest_Data,bc684c5b-5ee4-43cc-a40f-45faff66a5a7,Eider number of nest in the tundra- Mingan-Number of nest data_Data_dictionary,1124
+pc,d6e16c49-9994-442e-8a22-9c75d5a19616,Beaver - Kouchibouguac,8c2425ec-d524-4fa4-a955-9fa63173adf3,Beaver - Kouchibouguac - Data,2321
+pc,d6e16c49-9994-442e-8a22-9c75d5a19616,Beaver - Kouchibouguac,ff15168a-8f80-439c-8c9b-d075e63dc857,Beaver - Kouchibouguac - Metadata,926
+pc,d7a10e3a-672d-41d2-aea1-ab6fe5c5e344,Deer Browse - Spring - Thousand Islands,a9e2cc8f-64eb-47eb-83be-f3b8a605c54b,Deer Browse - Spring - Thousand Islands - Data,72868
+tbs-sct,d7aae979-e1e3-4017-a77b-b83bf9ae5f34,Direction on Enabling Access to Web Services - Survey Results,de9b01c1-0d69-482b-980c-e1764d574080,Direction on Enabling Access to Web Services - Survey Results,55977
+pc,d7e427bf-1a20-4b70-9f83-1f8e6223c1b2,Lake Fish Index - Yoho,0be930ba-7238-43b2-b38e-72492645d716,Lake Fish Index - Yoho,1670
+pc,d7e427bf-1a20-4b70-9f83-1f8e6223c1b2,Lake Fish Index - Yoho,45c95629-f94c-4eae-ad74-1548f628ef97,Lake Fish Index - Yoho - data dictionary,2866
+cra-arc,d7fce72c-6daa-453c-b471-6c1801a4217f,Individual Statistics by Tax Filing Method (ISTFM) – 2021 tax year,02f641c7-a6d3-4c7a-8b2d-bbdc30ec3066,Table 1 – ISTFM for All Returns Filed – Economic Characteristics – 2021 tax year,
+cra-arc,d7fce72c-6daa-453c-b471-6c1801a4217f,Individual Statistics by Tax Filing Method (ISTFM) – 2021 tax year,c5061a7a-6ef1-4aaa-91c2-99420d05b0ff,Table 2 – ISTFM for All Returns Filed – Demographic Characteristics – 2021 tax year,
+pc,d87383f6-5313-430d-8416-1b6d6e377e02,Black Oystercatcher Population – Pacific Rim,6e10535e-273f-4eca-a335-5e00a77a68fe,Black Oystercatcher - Pacific Rim - Nesting Counts - Data,8744
+pc,d87383f6-5313-430d-8416-1b6d6e377e02,Black Oystercatcher Population – Pacific Rim,829bc895-a528-4759-a075-8aeead993152,Black Oystercatcher - Pacific Rim - Resighting Matrix - Data Dictionary,3883
+tbs-sct,d8f85d91-7dec-4fd1-8055-483b77225d8b,Proactive Publication - Contracts,fac950c0-00d5-4ec1-a4d3-9cbebf98a305,"Contracts over $10,000",542326374
+tbs-sct,d8f85d91-7dec-4fd1-8055-483b77225d8b,Proactive Publication - Contracts,fa4ff6c4-e9af-4491-9d4e-2b468e415a68,Proactive Publication - Contracts Nothing to Report,8913
+tbs-sct,d8f85d91-7dec-4fd1-8055-483b77225d8b,Proactive Publication - Contracts,2e9a82e2-bb18-4bff-a61e-59af3b429672,Aggregated Total - Contracts $10K and under,78995
+tbs-sct,d8f85d91-7dec-4fd1-8055-483b77225d8b,Proactive Publication - Contracts,7f9b18ca-f627-4852-93d5-69adeb9437d6,"Contracts over $10,000 – Legacy Data",957109
+pc,d994583a-1f27-4d99-8c7c-29a9555a0747,Elk aerial surveys  - Jasper,8a5f47d9-ba63-43c3-849e-28aee433a242,Elk aerial surveys  - Jasper,8432
+pc,d9de539a-d6c2-4485-9b39-2fa50d6638eb,Yoho_NP_Forest_Winter Wildlife Corridor Tracking,31cc4512-51d3-49a4-a9c3-7abc802b0b1b,Winter Wildlife Corridors - Yoho,456389
+pc,da225c6b-f45e-4a87-96a5-0f6b05a2bfa3,Nesting Seabird Populations - Pacific Rim,be1626b4-bdd9-452d-a3cf-8e3596ee0dd9,Nesting Seabird Populations - Pacific Rim - Maximum Counts - Data,674
+pc,da225c6b-f45e-4a87-96a5-0f6b05a2bfa3,Nesting Seabird Populations - Pacific Rim,5729937f-ecd7-4efc-b50e-356782acd65e,Nesting Seabird Populations - Pacific Rim - Storm-Petrel Recapture Matrix - Data,12845
+pc,da225c6b-f45e-4a87-96a5-0f6b05a2bfa3,Nesting Seabird Populations - Pacific Rim,8529503b-dd2a-4a3e-b64b-7ac49600a191,Nesting Seabird Populations - Pacific Rim - Data Dictionary,978
+pc,da79ab09-fc92-47c0-8574-0db760bcb564,Banff_NP_Alpine_Pika Haypile Surveys,eca25cc7-d138-4df6-a5b1-22e4e33d4cfd,Banff NP Tundra Pikas 2011-2023 - data,661176
+pc,da79ab09-fc92-47c0-8574-0db760bcb564,Banff_NP_Alpine_Pika Haypile Surveys,1df86d72-fad1-4bb7-b8bc-f97dfcd4def7,Banff NP Tundra Pikas - data dictionary,643
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",01db1f29-c390-4a88-a961-f74e9f3048ed,Table 1A. Gender_Sector_Aggregate,1087
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",8da77e16-b973-4a7f-85c5-0a974e06a416,Table 1B. Gender_Sector_Size,2983
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",bae6cbe3-aeab-4e7e-bffd-bfeb7ead482e,Table 2. Sector_Province,3305
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",9b5fb118-8f33-4cad-81e7-1f36b453e0e7,Table 3A. Age_Sector_Aggregate,3325
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",ebb55a93-c1ac-498a-84bb-a2532615f4a9,Table 3B. Age_Sector_Size,9160
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",c33a46b1-77cf-4278-bb49-e055e42363ff,Table 4A. Employment_Category_Sector_Aggregate,2319
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",517783ad-744b-428c-9889-255b0100bdac,Table 4B. Employment_Category_Sector_Size,6114
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",2bdaacea-4d74-4815-956d-dc9bd673a8b2,Table 5A. Part_time_Reasoning_Sector_Aggregate,3296
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",8a03475c-4628-476f-a579-0bae113f4f49,Table 5B. Part_time_Reasoning_Sector_Gender,5787
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",bc4e7869-3a66-416b-be90-3ac8be380ab7,Table 6A. Weekly_Usual_Hours_Worked_Excluding_Overtime_Sector_Aggregate,5950
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",811cb3d9-1e9e-4d20-9d43-93a8fb72f123,Table 6B. Weekly_Usual_Hours_Worked_Excluding_Overtime_Sector_Gender,10599
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f7a294f4-f7a1-4c2a-a809-a1da16384933,Table 7A. How_Far_In_Advance_Schedule_Is_Known_Sector_Aggregate,3887
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",7ec9aacf-0b5e-413a-811b-b7a4c3621e86,Table 7B. How_Far_In_Advance_Schedule_Is_Known_Sector_Size,10332
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",0319c19b-b0c3-4022-a03f-91050bad79a5,Table 8A. Satisfaction_With_Ability_to_Meet_Family_Needs_With_Work_Schedule_Sector_Aggregate,3888
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",9bdbbcd1-f884-4645-a8c4-55b160828fdb,Table 8B. Satisfaction_With_Ability_to_Meet_Family_Needs_With_Work_Schedule_Sector_Gender,6860
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",ddb4221e-ded1-4f8b-873a-55cf96903fc6,Table 9A. Availability_Of_Flexible_Work_Arrangements_Sector_Aggregate,6083
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",b361a44c-0d20-4e6e-9441-1bff321d5dd2,Table 9B. Availability_Of_Flexible_Work_Arrangements_Sector_Size,16342
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",dd950767-662d-4d27-aa81-0ce6d75e73cd,Table 10A. Satisfaction_With_Flexible_Work_Arrangements_Available_Sector_Aggregate,2788
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",56dd8a80-f827-4c09-bf49-fd3ea4f72a8a,Table 10B. Satisfaction_With_Flexible_Work_Arrangements_Available_Sector_Size,7522
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",32b2747e-3fd8-451b-9156-bfe07ca68402,Table 11A. Frequency_Sending_Receiving_Work_Related_Emails_Calls_Texts_Outside_Work_Hours_Sector_Aggregate,3094
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",31af1940-cd89-469d-bc80-d0a977c80fab,Table 11B. Frequency_Sending_Receiving_Work_Related_Emails_Calls_Texts_Outside_Work_Hours_Sector_Size,8234
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",ab443cd7-0bc5-4d96-825a-3021ef9651b8,Table 12A. Weekly_Overtime_Hours_Sector_Aggregate,9605
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",01305b44-538b-4334-8035-8b441ea8bdbd,Table 12B. Weekly_Overtime_Hours_Sector_Size,27800
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",e7b87d19-f6ed-44e4-bb39-81409a03444f,Table 13A. Degree_Of_Pressure_To_Take_On_Overtime_Work_Sector_Aggregate,2551
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",1ba489da-2ab2-4c48-b3e2-7e742ac9f264,Table 13B. Degree_Of_Pressure_To_Take_On_Overtime_Work_Sector_Size,7196
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",623ef2b9-0d4d-4b42-a561-a25e072171db,Table 14A. Covered_By_Union_Contract_Or_Collective_Agreement_Sector_Aggregate,1642
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",60e92953-ef57-4d07-9b3f-1bb5c8cf7bdb,Table 14B. Covered_By_Union_Contract_Or_Collective_Agreement_Sector_Size,4251
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",c694644d-5d82-43c6-abdd-53072290d07f,Table 15A. Being_In_Favour_Of_A_Union_Sector_Aggregate,3557
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",e5e0b998-21fe-4488-ae2f-df1a769700c3,Table 15B. Being_In_Favour_Of_A_Union_Sector_Size,9586
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",cab2c85e-b653-4b4d-aa20-653edc5b099d,Table 16A. Employer_Pressuring_Or_Trying_To_Stop_Involvement_In_Union_Activities_Sector_Aggregate,1661
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",c771169c-f8a8-41b8-9635-33845929edba,Table 16B. Employer_Pressuring_Or_Trying_To_Stop_Involvement_In_Union_Activities_Sector_Size,4117
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",9fd82ef0-1371-46b5-9e69-336126101ed2,Table 17A. Personal_Knowledge_Of_Workplace_Safety_Rules_Sector_Aggregate,2325
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",acb60898-024e-4d6f-aca1-015f9d5a1614,Table 17B. Personal_Knowledge_Of_Workplace_Safety_Rules_Sector_Size,6166
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f167d0c7-dbe8-416b-af0b-f86ee212c5f2,Table 18A. Health_And_Safety_Training_In_Prior_2_Years_Sector_Aggregate,2754
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",23141d23-332a-4801-8439-dc5c9f573f00,Table 18B. Health_And_Safety_Training_In_Prior_2_Years_Sector_Size,7767
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",e2b316cd-9b93-4ece-926d-a3cc7c2959f8,Table 19A. Having_The_Tools_And_Equipment_To_Do_Safe_Work_Sector_Aggregate,2641
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",c1005c1f-3d21-496e-b1c3-72251713456c,Table 19B. Having_The_Tools_And_Equipment_To_Do_Safe_Work_Sector_Size,7106
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",344f3bd5-337f-4caf-9e83-ef541557a54f,Table 20A. Involved_In_Health_And_Safety_Decisions_Sector_Aggregate,3066
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",8b725dc3-a67d-4385-a4cc-f39a70511b90,Table 20B. Involved_In_Health_And_Safety_Decisions_Sector_Size,8240
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f7e69d07-81bc-43d9-ad64-8c0f8b73bb9e,Table 21A. Quickness_Of_Health_And_Safety_Issues_Being_Identified_And_Dealt_With_Sector_Aggregate,3008
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",9ce38179-66c8-4489-af3c-87b7275d0e95,Table 21B. Quickness_Of_Health_And_Safety_Issues_Being_Identified_And_Dealt_With_Sector_Size,8028
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",b07ee584-ce52-42a0-b899-acecdbd4b044,Table 22A. Right_To_Refuse_Unsafe_Work_Sector_Aggregate,1614
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",df4b5740-9851-427e-8df9-94d13cbb5d5b,Table 22B. Right_To_Refuse_Unsafe_Work_Sector_Size,4217
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",3270cef6-996a-435f-bf18-fa056d2e7fb5,Table 23A. Exposed_To_Unsafe_Working_Conditions_In_Prior_Two_Years_Sector_Aggregate,3824
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",1bf586ee-6381-419b-b6af-e116404ca5d9,Table 23B. Exposed_To_Unsafe_Working_Conditions_In_Prior_Two_Years_Sector_Size,10083
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",b1ede2bf-72a0-4d60-aea9-e95fe2734f6f,Table 24A. Exposure_To_Unsafe_Working_Conditions_Brought_To_The_Employer's_Attention_Sector_Aggregate,1170
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",98f22cd0-5e88-4926-9018-d71d2db4cc8d,Table 24B. Exposure_To_Unsafe_Working_Conditions_Brought_To_The_Employer's_Attention_Sector_Size,2091
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",b9844044-c72a-46c6-a392-c764d64e1c2f,Table 25A. Comfortability_With_Raising_Issues_Of_Workplace_Safety_Sector_Aggregate,3293
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",28ed0ee8-83ab-48d3-a2d8-3dc9d66052ff,Table 25B. Comfortability_With_Raising_Issues_Of_Workplace_Safety_Sector_Size,8828
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",63b2eee6-9e96-483f-84e1-13c53b14a8a5,Table 27A. Experiences_Of_Harassment_And_Violence_Sector_Aggregate,3575
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",54a44ab4-fd66-4f1c-924c-39933943c4f2,Table 27B. Experiences_Of_Harassment_And_Violence_Sector_Gender,6091
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",01729172-e5a8-4f3a-b786-df1c12c3e198,Table 28A. Received_Training_How_Harassment_Violence_Be_Prevented_In_The_Workplace_Sector_Aggregate,1125
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",66b04c89-b853-4486-b7eb-553d04bf0cc3,Table 28B. Received_Training_How_Harassment_Violence_Be_Prevented_In_The_Workplace_Sector_Size,2765
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",b366a219-4a35-4f0a-96be-f26aebcd99f7,Table 29A. Employer_Doing_Enough_To_Protect_Against_Harassment_And_Violence_Sector_Aggregate,3140
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f6bc0eab-fb48-43e1-9e89-c056ab0ecc44,Table 29B. Employer_Doing_Enough_To_Protect_Against_Harassment_And_Violence_Sector_Gender,5554
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",a9030d70-55c4-45d2-b153-8ce71667b8b2,Table 31A. Felt_Discriminated_Against_In_The_Prior_2_Years_Sector_Aggregate,8941
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",162fa057-b90d-46cf-8518-fc32c896087c,Table 31B. Felt_Discriminated_Against_In_The_Prior_2_Years_Sector_Gender,14606
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",80af5739-b8b0-4055-8b68-57f2261b7317,Table 32A. Employer_Provides_An_Employee_Assistance_Program_Or_Counselling_Service_Sector_Aggregate,1663
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",9a1e5b25-8ac6-4dcd-9523-19cc6d53ef21,Table 32B. Employer_Provides_An_Employee_Assistance_Program_Or_Counselling_Service_Sector_Size,4273
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",84d7a90a-f6ef-4181-b2f6-4e98bed498d1,Table 33A. Used_The_Employee_Assistance_Program_Or_Counselling_Service_Sector_Aggregate,1100
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",bd1f506e-e218-48f1-afcd-997655c316b2,Table 33B. Used_The_Employee_Assistance_Program_Or_Counselling_Service_Sector_Gender,1875
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",afac129d-4939-49ff-9d43-0290d9dfdc68,Table 35A. Days_Of_Paid_Vacation_Entitled_To_Tenure_Sector_Aggregate,20742
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",20697657-7733-490b-8305-ec7475dbe02d,Table 35B. Days_Of_Paid_Vacation_Entitled_To_Tenure_Sector_Size,57623
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",41881192-f375-4217-83c5-5dcaa960c297,Table 36A. Have_Taken_Leave_For_Mental_Health_Reasons_Sector_Aggregate,1087
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",df3e7f1b-5e5a-47eb-b6ba-77a36e81cf11,Table 36B. Have_Taken_Leave_For_Mental_Health_Reasons_Sector_Gender,1838
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",af37b5dc-4a1a-4d66-b15b-30c91ad7f7fa,Table 37A. Feel_Supported_To_Take_Leave_For_Mental_Health_Reasons_Sector_Aggregate,3856
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",17fb2f65-7796-40ea-a864-a4ae495850de,Table 37B. Feel_Supported_To_Take_Leave_For_Mental_Health_Reasons_Sector_Gender,6857
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",4397293e-ab87-4e43-95d0-2f2bfb0b50bb,Table 38A. Benefits_Offered_Sector_Aggregate,39675
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",7a64d69a-8bb6-4772-bc2d-b4b3360d1021,Table 38B. Benefits_Offered_Sector_Size,110084
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",1d111b4c-2178-415c-86f8-de2e3503d810,Table 39A. Frequency_Work_Related_Factors_Caused_Stress_Sector_Aggregate,43398
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",bbac700f-c6e4-4870-b0d0-d9d14022270a,Table 39B. Frequency_Work_Related_Factors_Caused_Stress_Sector_Size,125570
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",e87f4a21-5fb7-47e8-97dc-352bea6a32d5,Table 40A. Extent_Employer_Offers_Appropriate_Work_Life_Balance_Sector_Aggregate,2800
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",5132fc27-b624-4aa6-a041-2c89803e669e,Table 40B. Extent_Employer_Offers_Appropriate_Work_Life_Balance_Sector_Gender,4891
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",df02c818-3d26-4327-b963-491b9fa4c824,Table 41A. Would_Describe_Work_Environment_As_Psychologically_Healthy_Sector_Aggregate,4434
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",ad2399cb-805f-4bde-8e85-136fe3ec8984,Table 41B. Would_Describe_Work_Environment_As_Psychologically_Healthy_Sector_Gender,7717
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",6d947b06-ef2f-426f-956a-0746bbd69107,Table 42A. How_Work_Life_Balance_Could_Be_Improved_Sector_Aggregate,6468
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",210a4231-e017-4577-9fa8-930bfe0137ea,Table 42B. How_Work_Life_Balance_Could_Be_Improved_Sector_Gender,11839
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",6698d47e-3d2e-4e13-b596-c4fd18dc4dfa,Table 1A. Gender_Sector_Aggregate,1333
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",5066dce8-cea4-4e78-aea0-dce49880d738,Table 1B. Gender_Sector_Size,3147
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",bebfce2a-4928-4687-8de9-b33ef1d21f8c,Table 2. Sector_Province,3670
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",8358e87a-2683-4ec1-bd8b-c57f6952ff40,Table 3A. Age_Sector_Aggregate,4110
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",7493d4d0-4fcf-4165-b9e3-4ecd3823f3c1,Table 3B. Age_Sector_Size,9999
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",96d209ad-0ed7-4199-9b64-b64bf28778e7,Table 4A. Employment_Category_Sector_Aggregate,2884
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",dbf52963-b074-492a-a02a-b0dcc1004a14,Table 4B. Employment_Category_Sector_Size,6949
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",85bf990b-4f51-4e3c-8a0a-5b032a0a213d,Table 5A. Part_time_Reasoning_Sector_Aggregate,3937
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",cbea9dd0-6bf1-4c93-ae23-a715c50e7b30,Table 5B. Part_time_Reasoning_Sector_Gender,6831
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f05c5d60-6700-4da5-a1c1-aeb100849c20,Table 6A. Weekly_Usual_Hours_Worked_Excluding_Overtime_Sector_Aggregate,7043
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",a3e05cf0-afd2-42e5-a89c-2fe4c27afacc,Table 6B. Weekly_Usual_Hours_Worked_Excluding_Overtime_Sector_Gender,12421
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",e293ed80-3966-432e-832e-3b6cf480b8ab,Table 7A. How_Far_In_Advance_Schedule_Is_Known_Sector_Aggregate,4810
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",04c8ed99-4ca3-4323-8251-2e9269d9c094,Table 7B. How_Far_In_Advance_Schedule_Is_Known_Sector_Size,11715
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",c0e501ba-c0fc-43c7-ac90-f284ac0d048d,Table 8A. Satisfaction_With_Ability_to_Meet_Family_Needs_With_Work_Schedule_Sector_Aggregate,4364
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",70d3c3d5-503f-4166-b21e-0da65668cc38,Table 8B. Satisfaction_With_Ability_to_Meet_Family_Needs_With_Work_Schedule_Sector_Gender,7534
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",13ee88e9-015a-41ae-8c77-4b0e94b16ed2,Table 9A. Availability_Of_Flexible_Work_Arrangements_Sector_Aggregate,7679
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",a28a38d8-7303-4a70-883f-b79ad2093a81,Table 9B. Availability_Of_Flexible_Work_Arrangements_Sector_Size,18964
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",90966259-89ea-477d-9ec4-c30bae3047a6,Table 10A. Satisfaction_With_Flexible_Work_Arrangements_Available_Sector_Aggregate,3213
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",c448312b-44ee-4792-8c32-47546be3abf5,Table 10B. Satisfaction_With_Flexible_Work_Arrangements_Available_Sector_Size,7893
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",ba076bcb-5fc4-40cf-80f4-5f0aa35ca99b,Table 11A. Frequency_Sending_Receiving_Work_Related_Emails_Calls_Texts_Outside_Work_Hours_Sector_Aggregate,4014
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",3a92cffa-8977-4ee5-bea7-72f63d5c55ce,Table 11B. Frequency_Sending_Receiving_Work_Related_Emails_Calls_Texts_Outside_Work_Hours_Sector_Size,9784
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f5073b8a-5557-44d2-a512-c1690e60372d,Table 12A. Weekly_Overtime_Hours_Sector_Aggregate,13304
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",6413b631-1522-447e-888c-c0b0aa006d79,Table 12B. Weekly_Overtime_Hours_Sector_Size,36584
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",d373514d-fe69-4c84-9a3c-498b09772372,Table 13A. Degree_Of_Pressure_To_Take_On_Overtime_Work_Sector_Aggregate,3116
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",eacdbb14-79a7-471e-a142-cca15efc027c,Table 13B. Degree_Of_Pressure_To_Take_On_Overtime_Work_Sector_Size,8109
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",7d4da7d9-3a22-4d8c-8d58-30110474da46,Table 14A. Covered_By_Union_Contract_Or_Collective_Agreement_Sector_Aggregate,2018
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",ee46a260-75d0-4972-97fa-71d6273245df,Table 14B. Covered_By_Union_Contract_Or_Collective_Agreement_Sector_Size,4717
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",6eea312c-6ef9-41d0-9750-fe946a2c07f1,Table 15A. Being_In_Favour_Of_A_Union_Sector_Aggregate,4359
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",51927add-19da-47eb-9618-c275fb00c0a2,Table 15B. Being_In_Favour_Of_A_Union_Sector_Size,10694
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",28642f04-c8e2-40c8-a02a-726aa057d76c,Table 17A. Personal_Knowledge_Of_Workplace_Safety_Rules_Sector_Aggregate,2954
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",49a37158-736d-46af-8089-f45336b3ac78,Table 17B. Personal_Knowledge_Of_Workplace_Safety_Rules_Sector_Size,7155
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",50951c73-1e85-4af4-b12d-9fed8d4ae601,Table 18A. Health_And_Safety_Training_In_Prior_2_Years_Sector_Aggregate,3475
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f7821ec2-e0bc-43ac-acf4-4b9ebf286619,Table 18B. Health_And_Safety_Training_In_Prior_2_Years_Sector_Size,8919
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",3cf20fa3-d75f-4676-a889-2695315fa609,Table 19A. Having_The_Tools_And_Equipment_To_Do_Safe_Work_Sector_Aggregate,3369
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",cc2b9e5a-c312-4198-a149-bc328d078e60,Table 19B. Having_The_Tools_And_Equipment_To_Do_Safe_Work_Sector_Size,8320
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",b0a0906c-adc1-4065-9e66-4945ac904078,Table 20A. Involved_In_Health_And_Safety_Decisions_Sector_Aggregate,3885
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f9ace67b-2591-4027-863d-a091098783bb,Table 20B. Involved_In_Health_And_Safety_Decisions_Sector_Size,9563
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",26815625-b10a-4e45-a8f7-9c2093ad6005,Table 21A. Quickness_Of_Health_And_Safety_Issues_Being_Identified_And_Dealt_With_Sector_Aggregate,3742
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",2db8090f-cbce-4b30-ad1c-e621873feb08,Table 21B. Quickness_Of_Health_And_Safety_Issues_Being_Identified_And_Dealt_With_Sector_Size,9104
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",49a613e7-3118-4555-b87a-7b70c04f2d30,Table 22A. Right_To_Refuse_Unsafe_Work_Sector_Aggregate,2005
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",114a68a0-2f54-4a0c-a59f-59c7b47e16ef,Table 22B. Right_To_Refuse_Unsafe_Work_Sector_Size,4698
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",d8bce461-dad0-4896-9e3e-a8bd02ac89c8,Table 23A. Exposed_To_Unsafe_Working_Conditions_In_Prior_Two_Years_Sector_Aggregate,4696
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",5612fdb2-1707-4d56-922b-e9a9d42ec127,Table 23B. Exposed_To_Unsafe_Working_Conditions_In_Prior_Two_Years_Sector_Size,11305
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",d59411cd-258f-4273-bd2f-706781815fca,Table 24A. Exposure_To_Unsafe_Working_Conditions_Brought_To_The_Employer's_Attention_Sector_Aggregate,1452
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",5634fa9e-e770-47b7-b45e-47f941044374,Table 24B. Exposure_To_Unsafe_Working_Conditions_Brought_To_The_Employer's_Attention_Sector_Size,2360
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",a2193be3-e019-48fb-82ea-25d20c6373ee,Table 25A. Comfortability_With_Raising_Issues_Of_Workplace_Safety_Sector_Aggregate,3899
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",86542c2d-871f-463f-9889-8cbe10ed5e3c,Table 25B. Comfortability_With_Raising_Issues_Of_Workplace_Safety_Sector_Size,9560
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",4d9ace95-ff5c-41d6-9d36-79add8e162ce,Table 26A. Aware_Coworkers_Impaired__Under_Influence_Drugs_Alcohol_During_Work_Hours_Sector_Aggregate,1380
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",56e2fe9e-20af-4028-b1a7-15448140c132,Table 26B. Aware_Coworkers_Impaired__Under_Influence_Drugs_Alcohol_During_Work_Hours_Sector_Size,3082
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",856f5397-e561-4d0e-9486-473b0d990985,Table 27A. Experiences_Of_Harassment_And_Violence_Sector_Aggregate,3996
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",bbac2adb-d576-42fb-9c81-083df84c8e32,Table 27B. Experiences_Of_Harassment_And_Violence_Sector_Gender,6760
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",5243e6a5-1ed7-4c9f-af83-af0ee6dfb946,Table 28A. Received_Training_How_Harassment_Violence_Be_Prevented_In_The_Workplace_Sector_Aggregate,1399
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",ec3362cd-8d07-4f90-a707-c57f12dd9f3f,Table 28B. Received_Training_How_Harassment_Violence_Be_Prevented_In_The_Workplace_Sector_Size,3093
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",f7c03f3d-c230-42d2-bf4b-255173ae7688,Table 29B. Employer_Doing_Enough_To_Protect_Against_Harassment_And_Violence_Sector_Gender,6596
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",654b247b-5382-4574-ab1d-819825493ff4,Table 30A. Witnessed_Harassment_Or_Violence_Directed_At_Another_Person_In_The_Workplace_Sector_Aggregate,1360
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",e878389b-49f1-4900-944d-77c43a9242e1,Table 30B. Witnessed_Harassment_Or_Violence_Directed_At_Another_Person_In_The_Workplace_Sector_Size,3060
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",314ba557-c2b4-4c4b-8e82-09e542321511,Table 31A. Felt_Discriminated_Against_In_The_Prior_2_Years_Sector_Aggregate,9961
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",e6290a2e-76eb-4aaf-afea-757e40bfb06a,Table 31B. Felt_Discriminated_Against_In_The_Prior_2_Years_Sector_Gender,16526
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",26abccfd-70cf-46d3-9f32-6342c56682f9,Table 32A. Employer_Provides_An_Employee_Assistance_Program_Or_Counselling_Service_Sector_Aggregate,2046
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",52111bf2-cb3d-4bd7-9d99-76b3c8629aea,Table 32B. Employer_Provides_An_Employee_Assistance_Program_Or_Counselling_Service_Sector_Size,4758
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",e1c3515b-3a85-410f-b3e1-17276eafce7d,Table 33A. Used_The_Employee_Assistance_Program_Or_Counselling_Service_Sector_Aggregate,1267
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",74967e71-d7c1-4975-9b48-9409d0a7dedd,Table 33B. Used_The_Employee_Assistance_Program_Or_Counselling_Service_Sector_Gender,2105
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",0ee1167e-34c9-4ed8-aa79-2d609d59331c,Table 35A. Days_Of_Paid_Vacation_Entitled_To_Tenure_Sector_Aggregate,24808
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",bd867b8f-3213-48ff-8931-e1f11a78bdb3,Table 35B. Days_Of_Paid_Vacation_Entitled_To_Tenure_Sector_Size,64368
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",921d81a7-5748-4123-b874-3f5b8229ad02,Table 36A. Have_Taken_Leave_For_Mental_Health_Reasons_Sector_Aggregate,1256
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",8f8997f5-80dd-4a3d-9b7c-e91bd0c12165,Table 36B. Have_Taken_Leave_For_Mental_Health_Reasons_Sector_Gender,2088
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",2d825dcb-0a14-43cc-b258-0fcf05703f54,Table 37A. Feel_Supported_To_Take_Leave_For_Mental_Health_Reasons_Sector_Aggregate,4762
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",453944ca-7c52-4e28-b519-2e1b30e33e7f,Table 37B. Feel_Supported_To_Take_Leave_For_Mental_Health_Reasons_Sector_Gender,8429
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",4ebb47b6-6f42-42ea-b2c5-dcaca49fd4ac,Table 38A. Benefits_Offered_Sector_Aggregate,50954
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",bdf03852-4935-4d45-b4ae-22321e1e58b6,Table 38B. Benefits_Offered_Sector_Size,131433
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",6940380a-36e3-4556-9f85-f105edc80812,Table 39A. Frequency_Work_Related_Factors_Caused_Stress_Sector_Aggregate,53368
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",d04a9f8f-3e46-4935-b404-e2709126b3de,Table 39B. Frequency_Work_Related_Factors_Caused_Stress_Sector_Size,144082
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",9f3f4154-2ca3-4386-b65f-d0dfa9766c23,Table 40A. Extent_Employer_Offers_Appropriate_Work_Life_Balance_Sector_Aggregate,3217
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",0ad5b1dd-22ac-4661-8be7-e50b39604804,Table 40B. Extent_Employer_Offers_Appropriate_Work_Life_Balance_Sector_Gender,5497
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",a65978a7-fc8c-4611-8d9e-d59154eeebc2,Table 41A. Would_Describe_Work_Environment_As_Psychologically_Healthy_Sector_Aggregate,5196
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",12da0552-2d3c-4d0c-a2e8-55dff92478f5,Table 41B. Would_Describe_Work_Environment_As_Psychologically_Healthy_Sector_Gender,8965
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",30c54ce2-7d3c-444d-ac8f-ab81f243be31,Table 42A. How_Work_Life_Balance_Could_Be_Improved_Sector_Aggregate,8713
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",0c374ba2-aeac-4542-a2d1-4be2425d7f10,Table 42B. How_Work_Life_Balance_Could_Be_Improved_Sector_Gender,16019
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",56c65268-7bcb-4bfa-a0b0-581a17f61f05,Table of Contents,8201
+esdc-edsc,daaa2ce3-5ddb-4290-8a96-455cf8591953,"Survey of Employees under Federal Jurisdiction, 2022",7918c7d6-53ff-4f64-b532-13e141d5b5e9,Table of Contents,10672
+pc,dad96593-6f7c-47d6-a246-fb09a68a8bdd,Southern Flying Squirrel - Point Pelee,87065863-dcb0-45ee-8a95-9550f34b166f,Southern Flying Squirrel - Point Pelee - Monitoring Data Dictionary,1559
+pc,dad96593-6f7c-47d6-a246-fb09a68a8bdd,Southern Flying Squirrel - Point Pelee,b31054fd-6617-4453-8707-1ee972ea4e52,Southern Flying Squirrel - Point Pelee - Southern Flying Squirrel - Point Pelee - Monitoring Data,198448
+dfatd-maecd,dafecd72-7b1a-43eb-be5f-48707d77349c,3.5.2: Global Affairs Canada's Departmental Results Framework (DRF) Indicator 3.5.2,9684bff4-0599-42b0-ae8b-c199cce5054d,Global Affairs Canada's Departmental Results Framework (DRF) Indicator 3.5.2. - 2021-22,15902
+dfatd-maecd,dafecd72-7b1a-43eb-be5f-48707d77349c,3.5.2: Global Affairs Canada's Departmental Results Framework (DRF) Indicator 3.5.2,15d03785-f1ec-45b2-9ac1-087ae2d5fbe8,Global Affairs Canada's Departmental Results Framework (DRF) Indicator 3.5.2. - 2020-21,34421
+pc,db9895fb-2883-47c2-a1b1-2ed2a66e09cd,Alpine Vegetation - Nahanni,0fe95482-3fdb-4662-93d4-e75d3c98f85b,Alpine Vegetation - Nahanni - Data - 1,18997
+pc,db9895fb-2883-47c2-a1b1-2ed2a66e09cd,Alpine Vegetation - Nahanni,9c6c6355-1d15-49a5-9fe7-941ef445188a,Alpine Vegetation - Nahanni - Data - 2,52633
+pc,db9895fb-2883-47c2-a1b1-2ed2a66e09cd,Alpine Vegetation - Nahanni,30609d93-23f5-4805-8812-805c0ba91f44,Alpine Vegetation - Nahanni - Data dictionary,3992
+pc,dce738d6-4988-4714-9664-6c6e0775cb87,Stream flow - Kejimkujik,d0550470-4bd5-40fe-bada-f1a46845aca3,Stream Flow - Kejimkujik -Stream Profile Data - 1,5860
+pc,dce738d6-4988-4714-9664-6c6e0775cb87,Stream flow - Kejimkujik,f53812a6-84e0-4be6-b82b-3e20fc48a87a,Stream Flow - Kejimkujik - Water Level Data - 2,3775778
+pc,dce738d6-4988-4714-9664-6c6e0775cb87,Stream flow - Kejimkujik,9b9cff52-b338-4a8f-ae00-100e5d0da30d,Stream Flow - Kejimkujik - Data Dictionary,552
+cfia-acia,dd8af584-8f81-4d8d-b362-1d77503a2621,Food Microbiology - Targeted Surveys - 2016 - 2018 Bacterial Pathogens in Seed Powder and Plant-based Protein Powder - Final Report,dd273408-d6f3-41a5-a31c-2b778ac4380f,Food Microbiology - Targeted Surveys - 2016 - 2018 Bacterial Pathogens in Seed Powder and Plant-based Protein Powder - Final Report,1235725
+pc,ddd98f33-d155-45d5-9b14-a6b4ee186580,Shrub cover-Vuntut,c8c7917d-0833-4f92-91ff-2e06af1db3c7,Shrub cover-Vuntut,35547
+nrcan-rncan,de1f8f2a-2899-4469-8545-f247c717d112,Reducing pest risk in birch wood products - The effective heat treatment for bronze birch borer Agrilus anxius (Coleoptera: Buprestidae) prepupae,a1b6a35d-a660-49da-9807-a70d112ebf10,Data file,64381
+nrcan-rncan,de1f8f2a-2899-4469-8545-f247c717d112,Reducing pest risk in birch wood products - The effective heat treatment for bronze birch borer Agrilus anxius (Coleoptera: Buprestidae) prepupae,ed8bf28b-ccb7-45b8-8984-3b8898ec51e8,Data dictionary,3378
+esdc-edsc,de2bf291-1ccd-4f27-9dcd-8616b95bec6f,Work-Sharing (WS) Program Statistics,e7aae063-f86d-4314-8902-a6792da2dd51,"FY 2023-2024 - Work-Sharing (WS) Program Statistics as of March 30, 2024 (French)",2650
+tc,deb7066b-c94b-4f65-a4e3-6b99ff47a3e0,"Cost of Parts, Repair, and Overhaul per Hour of Flight on Selected Aircraft 2006-2016",22999668-dbad-4bb5-87c6-20f9881c5088,"Cost of Parts, Repair, and Overhaul per Hour of Flight on Selected Aircraft 2006-2016",2813
+cfia-acia,debeebfe-8e35-4914-8ad5-8432340e1e5a,CFIA 2015/2016 Deoxynivalenol in Selected Foods Data,90b59896-d874-4da5-9c03-580d7ee6c584,CFIA 2015/2016 Deoxynivalenol in Selected Foods Data,201445
+pc,def140b7-3cab-4d54-876d-9966c53b86c4,Forest Birds  - Georgian Bay Islands,06ce67b4-f84e-4c22-b675-412af668eadc,Forest Birds  - Georgian Bay Islands,88399
+pc,def140b7-3cab-4d54-876d-9966c53b86c4,Forest Birds  - Georgian Bay Islands,13992524-d446-446a-8ace-10e3e20e5c75,Forest Birds - Georgian Bay Islands,978
+pc,df10fe0d-3fc4-4e72-a16f-9c400d92ce10,Soft-shell clam - Kejimkujik,9002c351-a7e4-40fa-a4cd-a86b4c6bf320,Soft Shell Clams - Kejimkujik - Population Survey Data,22238
+opc-cpvp,df3df303-1f52-45dd-a347-05eb8bc4706f,2019‐20 Survey of Canadian businesses on privacy‐related issues,6f1d71ee-6dbf-4a2d-b4c2-7be45c1468da,2019-20 Survey of Canadian businesses on privacy-related issues - Dataset,110913
+pc,df69f65c-408d-4c66-89c4-20607d277005,Plant_phenology - Forillon,6f32d529-0425-4a41-ba7f-99cd9213f85f,Plants_phenology - Forillon - Data,141539
+pc,df69f65c-408d-4c66-89c4-20607d277005,Plant_phenology - Forillon,0b1b118b-18c9-471d-a7db-0248efa9a22c,Plants_phenology - Forillon - Data dictionary,1215
+pc,e01deaa3-bf2f-480a-9b81-26a4e3e52812,Aquatic-Water Connectivity - Glacier,15dc9e2b-e72c-45b2-afdf-cf0f9a03397b,Aquatic/Water Connectivity - Glacier,67843
+pc,e01deaa3-bf2f-480a-9b81-26a4e3e52812,Aquatic-Water Connectivity - Glacier,351b7567-1676-4a23-8976-05427c522f56,Aquatic/Water Connectivity - Glacier - data dictionary,981
+pc,e036c35b-9cc0-4eb6-9d51-2d81eb5867fc,Water Quality - Yoho,810444e4-3ede-466a-8c1a-5cb0cf7ab2b1,Water Quality - Yoho,727
+pc,e036c35b-9cc0-4eb6-9d51-2d81eb5867fc,Water Quality - Yoho,43e11e31-e7ea-4081-af0c-b20c805d3dc0,Water Quality - Yoho - data dictionary,1798
+pc,e0aa39b6-67c0-4863-bdad-d74e73870697,Migratory Shorebird Habitat Use - Pacific Rim,8ff77bcb-a6b9-4f72-8c52-3706388f2659,Migratory Shorebird Habitat Use - Pacific Rim - Data,75452
+pc,e0aa39b6-67c0-4863-bdad-d74e73870697,Migratory Shorebird Habitat Use - Pacific Rim,2cc9ffb1-34b9-4415-8f18-ed785f010ef3,Migratory Shorebird Habitat Use - Pacific Rim - Compliance - Data,586
+pc,e0aa39b6-67c0-4863-bdad-d74e73870697,Migratory Shorebird Habitat Use - Pacific Rim,adba87bf-f759-48b2-b272-6aa9a5f0f4b8,Migratory Shorebird Habitat Use - Pacific Rim - Data Dictionary,3334
+pc,e0b6208d-7ac2-4c94-8808-a169afff7bf9,Rangeland health assessments- Elk Island,3f97badb-2ff2-430b-be20-04533c25b702,Rangeland health assessments- Elk Island - Data Dictionary,41621
+pc,e0c54d69-5113-4d8f-8522-30e23dc7ab26,Northern Map Turtle - Georgian Bay Islands,fdaa6699-e6ec-4fe0-829e-56ffbc95484b,Northern Map Turtle - Georgian Bay Islands,1355
+pc,e0c54d69-5113-4d8f-8522-30e23dc7ab26,Northern Map Turtle - Georgian Bay Islands,26c0b69a-ac90-4fbb-a365-ec9d0249e2ab,Northern Map Turtle - Georgian Bay Islands - Data Dictionary,2069
+tbs-sct,e0d1f0bf-699f-437e-805d-4aaa428f96b8,5th National Action Plan on Open Government Reporting Data,0305a157-9d10-4ec2-8ca4-e39ab2b34396,NAP data,1140415
+pc,e0e8bd56-d029-4620-be6f-0f94afd71698,Swallows - Jasper,46257a0a-b363-4767-9c14-a997b01fd29f,Swallows - Jasper,1609
+pc,e0e8bd56-d029-4620-be6f-0f94afd71698,Swallows - Jasper,0ef7c3b5-7b85-4a20-a9e1-b368eb83aa5f,Swallows - Jasper - Data Dictionary,314
+cfia-acia,e18d527a-ca1a-455a-9bb4-4b74c8a819e6,Whole Genome Sequence for Foodborne Bacteria isolated by the Canadian Food Inspection Agency,22e7e0ed-b2da-42c4-b35d-ee69aa4b7e91,Published Genomes,242888
+cfia-acia,e18d527a-ca1a-455a-9bb4-4b74c8a819e6,Whole Genome Sequence for Foodborne Bacteria isolated by the Canadian Food Inspection Agency,5fbe8a8d-566c-4f35-897c-8d10ea19da43,CFIA Projects at NCBI,12560
+pc,e2273bb0-9391-4b44-8889-0152e59c6a6a,Wetland vegetation - Kejimkujik,b55a6b03-c701-42dd-b001-f35308186d84,Wetland Vegetation - Kejimkujik - Site Information Data - 1,2928
+pc,e2273bb0-9391-4b44-8889-0152e59c6a6a,Wetland vegetation - Kejimkujik,0841ecb8-8524-48a8-8bb4-ee3dfa249277,Wetland Vegetation - Kejimkujik - Vegetation Data - 2,96324
+pc,e2273bb0-9391-4b44-8889-0152e59c6a6a,Wetland vegetation - Kejimkujik,45f49aea-18d7-476d-a462-db49159124e9,Wetland Vegetation - Kejimkujik - Tree Data - 3,4788
+pc,e2273bb0-9391-4b44-8889-0152e59c6a6a,Wetland vegetation - Kejimkujik,a8c544df-6e31-473b-8d23-28f487c166b3,Wetland Vegetation - Kejimkujik - Data Dictionary - 4,8506
+pc,e2b69963-3cc8-4b49-9da4-1c455468befd,Trail Condition Index - Fundy,545e5c96-59a9-43de-80d4-137c6a3b2566,Trail Condition Index - Fundy,2252
+csec-cstc,e2d943c9-878b-42e3-ab27-b22e4700307d,2012-2023 Population growth for the Communications Security Establishment,8a8e7f25-bb61-4b78-8d10-02ebeec3df28,CSV EN/FR,150
+pc,e3f4414e-f3cd-4dc0-b45b-5960f27af13b,Progress towards completing Canada's National Park System,83a45d74-4a4c-4063-98e6-1838e011b99e,Progress towards completing Canada's National Park System 2021-2022,1530
+pc,e42cd1dc-4ed1-4afd-9c7f-5289612b7433,Stream hydrology - Torngat Mountains,2f9dc3d2-431b-4e70-b0a6-5a9cac643e1c,Stream hydrology and temperature - Torngat Mountains,10022998
+tc,e4471780-a128-416e-8975-9d88b35c40f9,"Labour Rate per Hour of Flying on Selected Aircraft, 2011-2016",2ccac92a-f1d1-41bf-b528-a9342ad8fec1,"Labour Rate per Hour of Flying on Selected Aircraft, 2011-2016",2036
+pc,e46f34b2-dc17-434b-b8dd-e39e73321d6a,Fire Regime - Riding Mountain,e02b9060-32cb-4605-a974-9d8bd7d515f3,Fire Regime - Riding Mountain,611
+pc,e4e19f7c-581b-4223-8a2d-fc4481964b6c, Regeneration - Georgian Bay Islands,0f55e8a6-7a04-4e95-95a0-5c55e9b47585, Regeneration - Georgian Bay Islands,88399
+pc,e4e19f7c-581b-4223-8a2d-fc4481964b6c, Regeneration - Georgian Bay Islands,0b1d94bd-ff57-4fd8-a596-f1b969562407, Regeneration - Georgian Bay Islands - Data Dictionary,978
+pc,e53fa300-3b7b-44e7-b14a-5d85669bf07d,Goose Terrestrial Assessment - Wapsuk National Park,7926ff87-6288-4688-974c-c030fd188356,Goose Terrestrial Assessment - Wapsuk National Park,697
+pc,e5b1633d-fe6e-4fc8-9509-3dd2396964aa,Parks Canada attendance 2021-2022,b00206db-9666-4d70-a922-5814109c1696,Parks Canada attendance 2021 22,5721
+psc-cfp,e61c8587-2cc9-4775-b34e-f1041ad00410,Advertisements to the Public Service ,82f58b1e-b90a-4397-9d20-2a554cb4e1da,Advertisements from the 2023-2024 fiscal year,4581190
+psc-cfp,e61c8587-2cc9-4775-b34e-f1041ad00410,Advertisements to the Public Service ,eace78ff-24c6-410f-a8ca-99d85536aa67,Advertisements from the 2022-2023 fiscal year,5794005
+psc-cfp,e61c8587-2cc9-4775-b34e-f1041ad00410,Advertisements to the Public Service ,3c45161b-ad62-450c-918c-a9ffd29d9d58,Advertisements from the 2021-2022 fiscal year,6301174
+psc-cfp,e61c8587-2cc9-4775-b34e-f1041ad00410,Advertisements to the Public Service ,90de37bf-0758-494e-b810-081fdb068f98,Advertisements from the 2020-2021 fiscal year,5249594
+psc-cfp,e61c8587-2cc9-4775-b34e-f1041ad00410,Advertisements to the Public Service ,bcda2288-079c-4127-ac32-fb16ef95aea1,Advertisements from the 2019-2020 fiscal year,6576516
+psc-cfp,e61c8587-2cc9-4775-b34e-f1041ad00410,Advertisements to the Public Service ,7d6190b2-3cc5-4d1f-8f7a-7d5bfde780e3,Advertisements from the 2018-2019 fiscal year,6827197
+psc-cfp,e61c8587-2cc9-4775-b34e-f1041ad00410,Advertisements to the Public Service ,24ef1656-3004-432a-9504-b3e15237eec4,Advertisements from the 2017-2018 fiscal year,6701410
+psc-cfp,e61c8587-2cc9-4775-b34e-f1041ad00410,Advertisements to the Public Service ,921c73bd-42a3-45cf-b2fb-a872ae197e58,Advertisements from the 2024-2025 fiscal year,2572608
+pc,e68c8852-0192-42cc-95b4-210c423be15e,Common nighthawk -Jasper,f1c45095-cae7-45f1-a6a3-b02547607a8a,Common nighthawk -Jasper,1363
+pc,e68c8852-0192-42cc-95b4-210c423be15e,Common nighthawk -Jasper,1dad5028-9b7a-4d29-a278-4d22caf22a6c,Common nighthawk -Jasper - Data Dictionary,855
+esdc-edsc,e6c250de-a41e-4c29-bf80-ee7c22d79c52,Net amount paid for Canada Pension Plan (CPP) disability benefits by province and calendar year ($'000),a7b02348-3e36-47f3-aba8-d0b882b72fa0,Net amount paid for Canada Pension Plan (CPP) disability benefits by province and calendar year,5552
+esdc-edsc,e6c250de-a41e-4c29-bf80-ee7c22d79c52,Net amount paid for Canada Pension Plan (CPP) disability benefits by province and calendar year ($'000),965cce0d-b9bd-451a-beba-64b54fc69a4e,Net amount paid for Canada Pension Plan (CPP) disability benefits by province and calendar year ,5562
+tc,e718cfd5-206f-44c0-b8bb-ebe475a578f4,Hazardous Waste Inventory Audit,5e34d392-9ce4-4fc1-ba4f-9fb686df91ca,Hazardous Waste Inventory Audit,4945
+cfia-acia,e750a5e1-40e5-4428-b23f-cc3f613e7f9a,2009-2010 Food Colours used in the Production of Manufactured Foods,9c6e2a16-c552-41cb-b95c-240db3c75b8d,2009-2010 Food Colours used in the Production of Manufactured Foods,33724
+pc,e7714291-d8ec-4418-b965-73f10234b7bb,Black bear and other forest mammal populations – Pacific Rim,22b96064-46b1-4dc5-915f-5de8c3fe84ce,Black bear and other forest mammals - Pacific Rim - Data,48171
+pc,e7714291-d8ec-4418-b965-73f10234b7bb,Black bear and other forest mammal populations – Pacific Rim,aababc4e-2d24-4b99-8d19-4ffafbd0307c,Black bear and other forest mammals - Pacific Rim - Data dictionary,1638
+pc,e778f182-947d-4ed3-87ce-c9c3f5aa7e3e,Riparian Health Assessments - Grasslands,f1838ded-4de1-4227-b824-854bbe116bf0,Riparian Health Assessments - Grasslands,97399
+pc,e778f182-947d-4ed3-87ce-c9c3f5aa7e3e,Riparian Health Assessments - Grasslands,04242b91-2b0c-4a54-b369-4365f8f9f8d6,Riparian Health Assessments - Grasslands - Data Dictionary,6819
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,da1135c5-a1df-4a07-a81e-de308ae6cce6,Annual Occupational Employment Projections,68582
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,7f0bf3be-c9ed-466b-bac8-f192a2776e0f,Annual Change of the Projected Occupational Employment,61795
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,faaf7627-ef31-4e25-950b-456bf3502c8d,Replacement Demand in the Form of Annual Retirement Estimates by Occupation,62717
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,e5f65bcf-fef0-4117-90c3-aac8d892e25d,"Job Openings Due to the Replacement Due to Emigration and In-Service Morality, by Occupation",61124
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,c74ec689-f642-4ea5-ae7d-3e6deeae504f,Summation of All Projected Demand Components by Occupation,63246
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,cad9faae-b8a8-4a07-b601-eda3bacfae95,Estimates of School Leavers Seeking Jobs by Occupation,62571
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,d44e6410-256f-4538-bdc9-11e83005d3d0,Annual Projections of New Immigrants Seeking Jobs by Occupation,61795
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,5c0f3437-7a6c-4eaf-a1c6-3e1122df4031,"Projections of Other Job Seekers by Occupation(occupational mobility, net re-entries, working students, etc.)",63275
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,b3bb5a99-7b8b-4589-bf7d-90d3e5254309,"Summation of All Projected Supply Components (school leavers, immigration and other job seekers) by Occupation",63196
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,f54650fb-606c-45fd-94c5-71ae638623ab,COPS Occupational Groupings,61139
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,fdb88d4c-14aa-4421-90c5-ccf3dd84eff6,Annual Employment Projections by Industry,6797
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,e108903d-bde3-4f11-9775-2cc3ad0df034,Annual Employment Growth Projections by Industry,5803
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,affd0c80-78cc-42fc-b8c4-94ee643e0827,Annual Retirement Projections by Industry,6009
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,b3e03d4e-26dc-4d32-ab4d-a32a684f6b53,Annual Projections of Other Replacement Demand (Emigration and in-Service Mortality) by Industry,5694
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,7bd410f6-9ba0-4aff-a482-b2c38204fbb4,Annual Projections of Total Job Openings by Industry,6003
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,6449394d-8998-41b7-a4e0-fa424f199a46,National Population Annual Projections by Gender and Age Groups,9615
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,6e42c114-4d4e-4538-95ea-d50d7f74c358,National Participation Rate Annual Projections by Gender and Age Groups ,7959
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,59c7f390-3239-44c7-95b7-692c305a2b93,National Participation Rate Annual Projections by Educational Levels,970
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,b5f9d1d4-0d6a-479b-8a05-262ac2243789,National Labour Force Annual Projections by Gender and Age Groups,8366
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,a18bfe92-94c0-4cec-a9d7-865d1ce766a7,National Labour Force Annual Projections by Educational Levels,1133
+esdc-edsc,e80851b8-de68-43bd-a85c-c72e1b3a3890,Canadian Occupational Projection System (COPS) - 2022 to 2031 projections,60c49627-ae69-4612-a68a-2b0e6b8e1b48,National Occupational Annual Retirement Rates Projections ,61427
+pc,e823c819-e09b-4211-ab7c-9149b6d10490,Stream hydrology - Gros Morne,12a70c30-dce6-4f5a-a490-c603b9010e7f,Stream thermal regime and hydrology - Gros Morne,26326979
+pc,e8401cb3-303c-4478-b725-6266a89ca5b0,Common Nighthawk - Kootenay,db3de80c-5449-4768-b7f5-b8431a9f56ae,Common Nighthawk - Kootenay,489
+pc,e8401cb3-303c-4478-b725-6266a89ca5b0,Common Nighthawk - Kootenay,b0800dba-34a2-4479-b4d3-c026fa618103,Common Nighthawk - Kootenay - data dictionary,246
+opc-cpvp,e86f5b03-afdc-489c-a7a3-7a5f08167ce6,2018-19 Survey of Canadians on Privacy,bb983347-2d7a-45a4-8065-81e1b3247d41,1.	2018-19 Survey of Canadians on Privacy - DATASET,160671
+opc-cpvp,e8f07d53-d94a-4297-9535-114e95513409,2020-21 Survey of Canadians on Privacy-Related Issues,faaa1146-2ce1-4829-b173-19076735275e,2020-21 Survey of Canadians on privacy-related issues – DATASET,206389
+opc-cpvp,e8f07d53-d94a-4297-9535-114e95513409,2020-21 Survey of Canadians on Privacy-Related Issues,11ced2af-457c-45a9-bab1-edc2157dc62d,2020-21 Survey of Canadians on privacy-related issues – DATASET,180955
+csec-cstc,e95a44a5-65b4-476f-aaae-f8406fd3e7fd,2011-2023 Age distribution for the Communications Security Establishment,459d0b77-1a26-4522-8206-6fc4c6af0902,CSV EN/FR,622
+csec-cstc,e9f71825-2d08-49d1-9725-bd4c0d77c8d1,2019-2023 Waste Diversion Report,d1cc1dec-afe3-4186-9d72-31cd7e782a90,CSV EN/FR,155
+esdc-edsc,ea639e28-c0fc-48bf-b5dd-b8899bd43072,Job Postings Advertised on Canada's National Job Bank Website,7b7bb8c9-c02f-4dea-9825-8240f38f5eef,November 2024 Job Postings Advertised on Canada's National Job Bank Website,
+esdc-edsc,ea639e28-c0fc-48bf-b5dd-b8899bd43072,Job Postings Advertised on Canada's National Job Bank Website,3db210bf-9be6-4539-b372-92809c9a8917,August 2024 Job Postings Advertised on Canada's National Job Bank Website,46576181
+esdc-edsc,ea639e28-c0fc-48bf-b5dd-b8899bd43072,Job Postings Advertised on Canada's National Job Bank Website,42c932ea-9c84-44be-b3f4-7b06ff0bb94e,August 2024 Job Postings Advertised on Canada's National Job Bank Website,46576610
+esdc-edsc,ea639e28-c0fc-48bf-b5dd-b8899bd43072,Job Postings Advertised on Canada's National Job Bank Website,2582692d-e2c5-42ea-aaee-7873bb82790d,June 2024 Job Postings Advertised on Canada's National Job Bank Website,42215786
+esdc-edsc,ea639e28-c0fc-48bf-b5dd-b8899bd43072,Job Postings Advertised on Canada's National Job Bank Website,a1ec1f66-7cd3-47bb-9ea9-15dc12773e1e,June 2024 Job Postings Advertised on Canada's National Job Bank Website,52450070
+pc,ea6f919c-213b-493c-bf07-bde1b7ac3f5b,Piscivorous Fish Population and Structure - Prince Albert,51504e34-ad75-4665-bff1-40d86cdcfbfa,Piscivorous Fish Population and Structure - Prince Albert - Effort Data - 1,14742
+pc,ea6f919c-213b-493c-bf07-bde1b7ac3f5b,Piscivorous Fish Population and Structure - Prince Albert,f45d4684-a446-4175-bbc6-c4d41353659e,Piscivorous Fish Population and Structure - Prince Albert - Catch Data - 2,21868
+pc,ea6f919c-213b-493c-bf07-bde1b7ac3f5b,Piscivorous Fish Population and Structure - Prince Albert,bf5a7b5e-0ef6-461b-be20-a903a227d1fb,Piscivorous Fish Population and Structure - Prince Albert - Catch Data Dictionary,1562
+pc,ea80308c-18ed-44e3-a646-9fb4ec6f37d0,Subtle Vegetation Change - Ukkusiksalik,dfb6aeac-25b5-4ff1-bd07-95d158ed7568,Subtle Vegetation Change - Ukkusiksalik,1087
+atssc-scdata,ea904072-2e58-4724-9024-a127b93171c6,2019-20 Departmental Results Report - Analysis of trends in spending and human resources,b555c176-fb0e-4c7f-a76d-541a2300d69c,Actual expenditures - Departmental spending trend graph ,325
+pc,eaa1ff9c-a07c-4292-911c-612f39d81afb,Parks Canada attendance 2001_02 to 2018_19,00d4c87a-5116-483f-8d99-66a263689940,Parks Canada attendance 2001_02 to 2018_19,24929
+pc,eaa1ff9c-a07c-4292-911c-612f39d81afb,Parks Canada attendance 2001_02 to 2018_19,173bde07-827b-403a-9b7f-d95c5e518cd0,Parks Canada attendance 2001_02 to 2018_19,23886
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,07ad6c4f-82f5-469a-bd99-f5e055d133f8,Aptitudes - Career Handbook (CH) -EN- 2016 Version 1.0,69316
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,9e3b3331-75fc-49a7-9c83-531bdca7f681,Aptitudes - Career Handbook (CH) -FR- 2016 Version 1.0,90061
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,35d2b32a-4243-4e95-b354-a1b444593fbe,Data People Things - Career Handbook (CH) -EN- 2016 Version 1.0,81267
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,33358d5f-50f9-4809-a250-eace9c3fb5e1,Data People Things - Career Handbook (CH) -FR- 2016 Version 1.0,104688
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,f11baf53-a8d7-47fe-8adf-75677fd70d11,Education Training - Career Handbook (CH) -EN- 2016 Version 1.0,90069
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,e2ffa455-b79c-44ce-8470-879212fd5110,Education Training - Career Handbook (CH) -FR- 2016 Version 1.0,140297
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,4438169d-c4a0-4f09-b7e3-8775747d057d,Environmental Conditions - Career Handbook (CH) -EN- 2016 Version 1.0,284380
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,28271db9-99c2-4b8e-a424-06068f177e93,Environmental Conditions - Career Handbook (CH) -FR- 2016 Version 1.0,388852
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,b527a563-a18f-4061-957d-de9c166daca5,Interests - Career Handbook (CH) -EN- 2016 Version 1.0,148928
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,a1001739-cc08-4491-8009-a9af09ffbc95,Interests - Career Handbook (CH) -FR- 2016 Version 1.0,210516
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,057e1af1-39f3-425d-845a-ba7ed8d154ea,Physical Activities - Career Handbook (CH) -EN- 2016 Version 1.0,61681
+esdc-edsc,eaaf7c87-8ffe-4d68-8110-91b533da2b6f,Career Handbook (CH) 2016 - Version 1.0,59046f5f-4477-4906-b28e-9a78c736e2a7,Physical Activities - Career Handbook (CH) -FR- 2016 Version 1.0,82035
+psc-cfp,eabf3929-aeb3-445e-82ac-cc7b56715ae9,Catalogue of Visit Notes for the President of the Public Service Commission of Canada with Newly Appointed Deputy Heads,bc72da60-5bb0-4ef2-8de7-b8b9c17c9d2e,Catalogue of Visit Notes for the President of the Public Service Commission of Canada with Newly Appointed Deputy Heads,2388
+psc-cfp,eabf3929-aeb3-445e-82ac-cc7b56715ae9,Catalogue of Visit Notes for the President of the Public Service Commission of Canada with Newly Appointed Deputy Heads,9536290e-368e-47de-8f7b-c6f0e95d4b05,Organizations Master List - Supporting Documentation ,7373
+cfia-acia,eacc89a4-f6ec-492a-8e2f-5edd561d35fa,"CFIA 2015/2016 Undeclared Egg, Gluten, and Soy in Candy Data",a4df0278-8096-4882-8c9c-428cd399c4b9,"CFIA 2015/2016 Undeclared Egg, Gluten, and Soy in Candy Data",107185
+cfia-acia,ebf469a4-b6d7-49fd-8994-2ef3af9ec5e9,CFIA-Undeclared Allergens and Gluten in Halloween themed Candies and Chocolates - 2018-2019 ,fd80af26-5a76-4b7e-9104-08197c9a91ed,CFIA-Undeclared Allergens and Gluten in Halloween themed Candies and Chocolates - 2018-2019 ,417153
+pc,ec3b6dde-9a66-4cc0-9d1e-cb53ee8fd98a,Forest Birds - Pukaskwa,032c5517-c888-4057-9f47-805662bc7a57,Forest Birds - Pukaskwa - Survey Data,363780
+pc,ec3b6dde-9a66-4cc0-9d1e-cb53ee8fd98a,Forest Birds - Pukaskwa,45f2d96f-88dd-492c-9c5e-e87c24aec6c4,Forest Birds - Pukaskwa - Data Dictionary,1005
+pc,ec7c742b-e9c5-4713-920b-54ca4931d62d,Mingan_NPR_Coastal_Seabirds_1984_2022,cada6511-e0e9-49ed-a62c-421a5e78820d,Mingan_NPR_Costal_SeaBird_Alcides_1984-2022_Data,137938
+pc,ec7c742b-e9c5-4713-920b-54ca4931d62d,Mingan_NPR_Coastal_Seabirds_1984_2022,2eaf1e6f-95ad-47ee-b6a3-1621b335ab14,Mingan_NPR_Coastal_Seabirds_MOTR_1986_2023_Data,43186
+pc,ec7c742b-e9c5-4713-920b-54ca4931d62d,Mingan_NPR_Coastal_Seabirds_1984_2022,945c0e53-4806-4073-8bb6-0362f0d71d79,Mingan_NPR_Coastal_Seabirds_MOTR_1986_2022_DataDictionary,7003
+pc,ec7c742b-e9c5-4713-920b-54ca4931d62d,Mingan_NPR_Coastal_Seabirds_1984_2022,9afee926-4b2c-44bd-b7ed-810d1c9a1177,Mingan_NPR_Costal_SeaBird_Alcides_1984-2022_DataDictionary,6010
+pc,ec8b841e-a3ff-496f-8f69-b98f6e91bf5f,Area disturbed by Fire - Waterton Lakes - Conservation and Restoration project (Fescue),215f9aac-6502-4633-b148-c27d81e064b9,Area Disturbed by Fire - Waterton Lakes - Core Fescue data - 1,1211
+pc,ec8b841e-a3ff-496f-8f69-b98f6e91bf5f,Area disturbed by Fire - Waterton Lakes - Conservation and Restoration project (Fescue),f4d2e626-74a6-4793-bf27-a4a5788d5525,Area Disturbed by Fire - Waterton Lakes - Core Fescue data dictionary - 2,1222
+pc,ecaa2369-ea6d-492f-ad47-6df0d38164a8,Salamanders - Kejimkujik,33c24dac-e9f3-406b-8675-9e64e76ba3d5,Salamanders - Kejimkujik - Population Survey Data - 1,2890
+pc,ecaa2369-ea6d-492f-ad47-6df0d38164a8,Salamanders - Kejimkujik,5860ea8c-7943-4ba4-ac3a-55ad94794c15,Salamanders - Kejimkujik - Site Information Data - 2,669
+pc,ecaa2369-ea6d-492f-ad47-6df0d38164a8,Salamanders - Kejimkujik,e2830b28-c9b1-4f69-a438-c0e4cf4a4319,Salamanders - Kejimkujik - Data Dictionary - 3,2890
+tbs-sct,ecd1a913-47da-47fc-8f96-2432be420986,Proactive Disclosure - Question Period notes,c55a2862-7ec4-462c-a844-22acab664812,Question Period Notes,68420008
+tbs-sct,ecd1a913-47da-47fc-8f96-2432be420986,Proactive Disclosure - Question Period notes,dba8cc4a-2a57-435c-a270-fa024474e609,Nothing to Report,3869
+dfatd-maecd,ece743aa-514a-4024-93c6-7f5ed5cd4eb2,Heads of Missions,73c0a35b-78fa-41d7-8429-4731edc913d3,Heads of Missions by Country - 2023,290781
+dfatd-maecd,ece743aa-514a-4024-93c6-7f5ed5cd4eb2,Heads of Missions,cb8b2bab-1a72-48a5-8faf-38b7a1158bae,Heads of Missions by Person - 2023,156396
+dfatd-maecd,ece743aa-514a-4024-93c6-7f5ed5cd4eb2,Heads of Missions,0a819fe4-33cb-4b76-aec1-512312b1efc5,Heads of Missions by Person Postings - 2023,93902
+pc,ed4e38c9-f140-4b50-b55c-6c75eeeb48b7,Beaver - Forillon,bef3d0ee-ec5f-4393-8ea3-9c5874781ce8,Beaver - Forillon - Data,34241
+pc,ed4e38c9-f140-4b50-b55c-6c75eeeb48b7,Beaver - Forillon,31fb3a53-e5c7-4f5b-9da0-6f798d9b810c,Beaver - Forillon - Data dictionary,560
+pc,ed53f807-d9d3-41b2-ad75-80e8649ac4d4,Restoration Actions - Waterton Lakes - Conservation and Restoration Project (Five needle pine),2c81e924-dcd4-4e84-afb0-3a5bf2178a8c,Restoration Actions - Waterton Lakes - Five-needle pine data - 1,482
+pc,ed53f807-d9d3-41b2-ad75-80e8649ac4d4,Restoration Actions - Waterton Lakes - Conservation and Restoration Project (Five needle pine),bdab925e-d121-442f-b3c4-5bfda2df37b7,Restoration Actions - Waterton Lakes - Five-needle pine data dictionary - 2,468
+pc,ed8981ff-c8b3-42e7-b02c-1d1b0373a991,Active Layer - Qausuittuq,29e9944a-a61d-4771-8377-8fe471cff449,Active Layer - Qausuittuq,
+pc,eddc5332-42e8-40c1-94df-95c43cc23ba1,Invasive Plant Cover - Waterton Lakes - Conservation and Restoration Project (Fescue),a3003e1f-6e99-43e4-9ded-96b98827bf3d,Invasive Plant Cover - Waterton Lakes - percent cover and density data - 1,8312
+pc,eddc5332-42e8-40c1-94df-95c43cc23ba1,Invasive Plant Cover - Waterton Lakes - Conservation and Restoration Project (Fescue),fce5f9e7-2991-4856-987a-4d2793e2a449,Invasive Plant Cover - Waterton Lakes - percent cover and density data dictionary - 2,2272
+hc-sc,ededff77-a021-48d6-89a5-cdbcd75fb4ff,Pest Management Regulatory Agency (PMRA) List of Formulants ,5dc86d17-6ae2-4d77-bb6f-cb2c0aae41e4,PMRA List of Formulants - Single Substance,155956
+hc-sc,ededff77-a021-48d6-89a5-cdbcd75fb4ff,Pest Management Regulatory Agency (PMRA) List of Formulants ,c29f87cd-2c2a-4ecd-ba8c-cb6a70222ca9,PMRA List of Formulants - Trade Name,231672
+tbs-sct,ee9bd7e8-90a5-45db-9287-85c8cf3589b6,Proactive Disclosure - Briefing Note Titles and Numbers,299a2e26-5103-4a49-ac3a-53db9fcc06c7,Proactive Disclosure - Briefing Note Titles and Numbers,44904547
+tbs-sct,ee9bd7e8-90a5-45db-9287-85c8cf3589b6,Proactive Disclosure - Briefing Note Titles and Numbers,5e28b544-720b-4745-9e55-3aac6464a4fb,Proactive Publication - Briefing Note Titles and Numbers Nothing to Report,7843
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),103d18f2-dbae-47ba-b15c-68877b21e968,Labels 2023 v1.0,37226
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),97e5f5a7-e865-4e7e-bd8e-903d8359618d,Labels 2023 v1.0,56915
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),d2ad2407-7105-4f5d-9bb1-83a8d67e6d61,Lead Statement 2023 v1.0,179340
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),a6c9d702-21ca-4641-86d6-40d556b3929c,Lead Statement 2023 v1.0,237050
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),d8187994-6197-4c01-83e3-69f41337b173,Workplaces Employers 2023 v1.0,232328
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),b92c04f2-00f7-40a8-b170-9e279382b9f9,Workplaces Employers 2023 v1.0,330283
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),fb173460-13ce-4f76-a06c-294bd74fd0af,Example Titles 2023 v1.0,914150
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),6ff1e339-f922-48d8-b6b0-ae5a24b16c2f,Example Titles 2023 v1.0,1423417
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),51f69e32-4a70-4771-a33e-972dd1fdfd16,Main Duties 2023 v1.0,544329
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),96f8791d-26cb-4e92-ac4f-99e61ee7f54f,Main Duties 2023 v1.0,721370
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),889d37bb-4377-4a54-82a4-a76e1a05103d,Employment Requirements 2023 v1.0,350463
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),2b8876b7-fff7-4704-a01b-33989afd2e0c,Employment Requirements 2023 v1.0,419979
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),ccffcef6-f3b1-4026-ba19-f502d077246f,Additional Information 2023 v1.0,139275
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),e4b1f634-73f4-4cb0-aaa4-3c185ea51e69,Additional Information 2023 v1.0,165264
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),d8d079ce-7a37-446b-adca-1237e15c362f,Exclusions 2023 v1.0,61538
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),476ff639-97a2-4da4-9c2b-756b1c4b2b91,Exclusions 2023 v1.0,67388
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),9dd7858f-4e7f-4a62-b0ea-4327fde45a30,Guide 2023 v1.0,87691
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),4dfd76d1-7d14-4d27-adef-0154412cc574,Guide 2023 v1.0,105853
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),cc38de47-b7d6-4282-b967-d4cb12474f07,Skills 2023 v1.0,97339
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),e4444042-ebb7-4833-876c-0b44a3a9f685,Skills 2023 v1.0,116123
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),01bc4d5b-b0e2-4e3d-ab61-f1f70e817293,Abilities 2023 v1.0,126363
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),80b87ff3-114e-4ee2-a021-3921cf01dbe5,Abilities 2023 v1.0,146282
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),02895126-4eb2-430d-b780-ef74cc0a3332,Personal Attributes 2023 v1.0,60846
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),9ccc6a35-6b1f-42bf-be2f-229d99efa3ae,Personal Attributes 2023 v1.0,80552
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),4ff79fb8-b858-466b-9806-bf7fba2b9b12,Knowledges 2023 v1.0,117339
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),f8b831d6-ea5a-4875-b426-e4596e0a00b7,Knowledges 2023 v1.0,137152
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),bc6c40c7-1ec4-47ec-a0ad-53df2fe7f9ad,Interests 2023 v1.0,42491
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),d61a880b-7859-47b6-8e18-651c6fde5415,Interests 2023 v1.0,62169
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),f551127e-3ca6-4f04-8523-28a92d6dbdd2,Work Activities 2023 v1.0,109597
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),d9041aae-295c-4fa4-acaf-d3bc3b112420,Work Activities 2023 v1.0,129529
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),0bb3613f-436b-4d42-8f88-78defd9208fd,Work Context 2023 v1.0,157693
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),aa323a39-7fef-4ae5-9b7c-d5956570e229,Work Context 2023 v1.0,177084
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),f1b0b3c4-8982-4104-ba96-794044ad65e8,Lead Statement 2022 v1.0,179340
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),c41c84ee-0df4-43ec-8690-bbd2424eed83,Lead Statement 2022 v1.0,237050
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),c3e16f83-5d09-43be-b1b4-49526cc25ed8,Workplaces-Employers 2022 v1.0,232328
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),84ee84bb-90e8-41be-b9f5-b1807b895404,Workplaces-Employers 2022 v1.0,330283
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),266f49d4-59ba-4c50-8171-bc7fde509eda,Example Titles 2022 v1.0,914150
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),77e0f199-93c9-466c-9643-c52e7f62820e,Example Titles 2022 v1.0,1423417
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),7453d044-7b41-44cc-b9c6-1112e9e886b5,Main Duties 2022 v1.0,544329
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),7f0337ed-aaab-46a9-a988-1c50286770c7,Main Duties 2022 v1.0,721370
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),b12666f4-cba7-405e-9610-f36318e0f7d5,Employment Requirements 2022 v1.0,350463
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),1852cf7f-5c40-49ab-b2dc-5d1180545166,Employment Requirements 2022 v1.0,416569
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),0b56ac41-244f-40ca-8c52-a5e376d3e72a,Additional Information 2022 v1.0,178108
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),c8813ce9-49d2-45fb-b903-bf89f29816d9,Additional Information 2022 v1.0,234447
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),1b620e35-a81b-4910-8876-7e83ae94dadf,Exclusions 2022 v1.0,61538
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),2cece57a-b0c6-4dc4-8ff4-8193c0426663,Exclusions 2022 v1.0,67388
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),dbc090d9-98ef-4d84-84c0-a2568f759756,Guide 2022 v1.0,43473
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),ec9b94d5-6e5b-4271-a3d2-20f34b388bf8,Guide 2022 v1.0,54382
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),34eecbcc-c3aa-4568-8715-c946de99df33,Skills 2022 v1.0,96395
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),9376bda5-2d80-4b0b-a34d-cf5d64d9b9a8,Skills 2022 v1.0,116127
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),e1d0f684-4f3d-4f6a-adc8-b3a9d0e120fd,Abilities 2022 v1.0,126634
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),2aed2904-4db4-45f5-8ca8-121de70d2815,Abilities 2022 v1.0,146272
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),42a2b00e-94f3-4168-81c4-c8bf671e1562,Personal Attributes 2022 v1.0,60875
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),be3b4321-a730-4d86-8004-29779282f02c,Personal Attributes 2022_v1.0,80539
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),2315640d-6bb5-4914-9a46-e8226829e2c0,Work Activities 2022 v1.0,109626
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),28a77959-c72e-4c55-82e7-9a8cdbae7ecd,Work Activities 2022 v1.0,129564
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),2eaf68a6-de91-4366-b3d0-d55f3732ec8c,Work Context 2022 v1.0,156980
+esdc-edsc,eeb3e442-9f19-4d12-8b38-c488fe4f6e5e,Occupational and Skills Information System (OaSIS),8696d108-77a9-4eb1-a995-10bfd4905602,Work Context 2022 v1.0,177136
+tc,ef91d197-7cdc-4864-a8c3-5dbbd88154e2,WHMIS Label and Cleaning Room Audit,0b42da56-13bd-4d41-b0e4-75c5c0d840a0,WHMIS Label and Cleaning Room Audits,3976
+pc,f05df5a8-561d-4c85-8547-e30f86005820,Plant Species Richness - Kluane,abea8231-837b-4103-b67c-ca1e794a95f9,Plant Species Richness - Kluane,21383
+pc,f08556f7-2c16-4dd9-904e-c967f0adcf22,Old-growth Forest Extent- Pacific Rim,6a9e23b5-35dc-47f9-b900-75a816327a14,Old-Growth Forest Extent - Pacific Rim - Data,1136
+cfia-acia,f0aa9c6f-984f-4cc8-a7d7-b679c6e64e10,2019-2020 Non-Permitted Food Colours in Red Palm Oil Data,be73ef42-6be8-430d-b663-d5888a774c9f,2019-2020 Non-Permitted Food Colours in Red Palm Oil Data,232260
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,f03d7f32-6d7c-467f-8dd7-3c0246808b7a,Population of the federal public service,515
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,d8e4906d-54a5-4d4b-8fca-9a7dd1bfa72e,Population of the federal public service,515
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,3391238b-f537-4231-8572-493b9392565b,Population of the federal public service by department or agency,69607
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,8cf7d2a4-ef28-42cb-81fe-0ba86de0e9d5,Population of the federal public service by department or agency,77854
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,6d238af7-2212-4d36-8ee3-abbfba4392c7,Population of the federal public service by department and tenure,265736
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,785ef530-2e43-4975-b9cd-1e8b1b9834ae,Population of the federal public service by department and tenure,332450
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,33a658fe-3d05-4344-af2b-f462d5c1e6b7,Population of the federal public service by department and province or territory of work,574064
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,75a7b02d-7ed5-4dc2-896f-f971a2fcfbcd,Population of the federal public service by department and province or territory of work ,645146
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,baa05779-9c69-40c9-ba42-875b340b5c47,Population of the federal public service by department and age band,713266
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,4358cfc1-d407-4289-94e2-23c5337aa0e1,Population of the federal public service by department and age band,795236
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,cb8b52a3-8a2a-4f2b-ba71-50479a2e6b23,Population of the federal public service by department and average age,70468
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,68d38a68-060f-4f3e-bb01-f71beb6ae353,Population of the federal public service by department and average age,78713
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,f11fa61f-9a5b-4b8a-b9ab-280ca332443f,Population of the federal public service by department and executive level,319650
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,bfe2f632-57b4-4bb6-8704-4ddaf258dd62,Population of the federal public service by department and executive level,353164
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,1608d1f4-3667-4322-b676-11e2ae292289,Population of the federal public service by department and first official language,187564
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,0d56ee98-2845-47bc-9316-b0e3fab3a9d8,Population of the federal public service by department and first official language,216017
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,a45bb8c6-8df9-4a02-bb18-730f01e3e8a4,Population of the federal public service by department and sex,157044
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,3912f1dd-746f-42b9-81fc-c461e16d6da0,Population of the federal public service by department and sex,182343
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,b65fa174-d925-4b20-bf10-0c41e8cbae41,Population of the federal public service by province or territory of work and tenure,34190
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,facdc26a-c78c-418b-8852-39bbd100dab7,Population of the federal public service by province or territory of work and tenure,43707
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,f01491b6-b572-4ed5-a617-c7364743a5ed,Population of the federal public service by province or territory of work,14235
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,e415e28b-b692-4b4a-b9e6-4ff53808b303,Population of the federal public service by province or territory of work,15127
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,69e4fc7c-565f-45d8-8074-bbdb5e6915be,Population of the federal public service in the National Capital Region,2069
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,d23cce21-5ef8-405a-8f2d-f204d8f9db06,Population of the federal public service in the National Capital Region,2077
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,eae46131-fc5b-4da5-95ca-6276d9a3ab47,Population of the federal public service by tenure,3174
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,a47793e8-4748-49e2-87c7-e5d1ac6b574c,Population of the federal public service by tenure,4345
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,46e49e6d-72ee-4dc8-a664-5fcfe32a133b,Population of the federal public service by first official language,2122
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,af4c88a5-76d2-4935-9ef7-ae3d9bef6d4e,Population of the federal public service by first official language,2395
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,ea4af82d-0ab5-4811-87b0-f7ae4251ef2a,Population of the federal public service by age band,7174
+tbs-sct,f0d12b41-54dc-4784-ad2b-83dffed2ab84,Federal public service statistics,cc4d0a5f-ca94-4c07-8348-51ed6c24ea5a,Population of the federal public service by age band,7314
+pc,f1052872-1086-4354-bff5-db5a32f1a546,Freshwater Benthic Macroinvertebrate Index - Jasper,9afd6437-0ee2-4b5f-82bd-23c4789def32,Freshwater Benthic Macroinvertebrate Index  - Jasper,1571
+pc,f1052872-1086-4354-bff5-db5a32f1a546,Freshwater Benthic Macroinvertebrate Index - Jasper,2d32b0e4-2048-4e41-8be7-44a09ac19813,Freshwater Benthic Macroinvertebrate Index  - Jasper - Data Dictionary,532
+atssc-scdata,f12ba1a4-99c0-4b4a-ac69-e57de57cddfe,2016-2017 Departmental Results Report - Program 1.1: Tribunal Specialized and Expert Support Services,233e6a9e-0d5b-4c10-b273-47e44745e03b,Results achieved,688
+tbs-sct,f132b8a6-abad-43d6-b6ad-2301e778b1b6,Proactive Disclosure - Position Reclassification,bdaa5515-3782-4e5c-9d44-c25e032addb7,Proactive Disclosure - Position Reclassification,2942110
+tbs-sct,f132b8a6-abad-43d6-b6ad-2301e778b1b6,Proactive Disclosure - Position Reclassification,1e955e4d-df35-4441-bf38-b7086192ece2,Proactive Disclosure - Position Reclassification Nothing to Report,103598
+pc,f140e1d0-ed60-4818-85d6-f02fcb69fda1,Snowpack - Wapusk National Park,bc0d0db6-fc48-425c-8f33-b4acc28e7d2e,Snowpack - Wapusk National Park,128925
+pc,f140e1d0-ed60-4818-85d6-f02fcb69fda1,Snowpack - Wapusk National Park,33d51f54-f17f-4aeb-a079-74372dc950b0,Snowpack - Wapusk National Park - Data Dictionary,2565
+pc,f1683c33-7ca1-4fba-9f56-c64e7fe5da9e,Grassland primary productivity - Elk Island,c9c795b1-f6b5-4063-8725-8fd1bb4916b8,Grassland primary productivity - Elk Island,1818
+pc,f1683c33-7ca1-4fba-9f56-c64e7fe5da9e,Grassland primary productivity - Elk Island,0ef78af3-b09d-4ca3-bb25-fe3f9a0ac630,Grassland primary productivity - Elk Island - Data dictionary,704
+pc,f17e60ca-9a45-47b0-ba1e-2cf8313e6570,Water Quality Simplified - Ivvavik,4a36fe88-9a55-4485-9fae-d60b56314ced,"Water Quality Simplified - Ivvavik - Nutrients, Physicals ,and Major Ions - 2015-2017 - data - 1",8129
+pc,f17e60ca-9a45-47b0-ba1e-2cf8313e6570,Water Quality Simplified - Ivvavik,bbdb7535-c7bb-47dd-a9f3-3f749cb45f4e,Water Quality Simplified - Ivvavik - total metals - 2015-2017 - data - 2,13690
+pc,f17e60ca-9a45-47b0-ba1e-2cf8313e6570,Water Quality Simplified - Ivvavik,5b8fa7af-6e25-4bd2-9749-fc8b67a7e65e,Water Quality Simplified - Ivvavik - 2015-2017 - data dictionary,916
+esdc-edsc,f1df637b-5c1a-43b5-8867-32b15b633a7a,"Average monthly payments for new Canada Pension Plan (CPP) disability beneficiaries by age group, gender and calendar year ($)",e9149d5b-822a-484f-a85a-7235ad2416ab,"Average monthly payments for new Canada Pension Plan (CPP) disability beneficiaries by age group, gender and calendar year",2356
+esdc-edsc,f1df637b-5c1a-43b5-8867-32b15b633a7a,"Average monthly payments for new Canada Pension Plan (CPP) disability beneficiaries by age group, gender and calendar year ($)",baee413b-2386-4eaf-b854-42fe9d21d5e6,"Average monthly payments for new Canada Pension Plan (CPP) disability beneficiaries by age group, gender and calendar year",2546
+pc,f20f05f2-1923-47dd-a0e5-3e6f0d2f682f,Lemming Population - Tuktut,4040a70a-9dfd-4e43-9104-00f5128188cc,Lemming population - Tuktut - 2011-2017 - data,820
+pc,f22428ec-8153-40ec-a33d-b77b1122d7e4,Greater Sage-Grouse Habitat Assessment - Shrublands,a7719a4d-9686-4286-a200-5c1743da2683,Greater Sage-Grouse Habitat Assessment - Grasslands,56954
+pc,f236214e-4d1b-40c6-8ecc-d62664f5c2b0,Coastal Plants - Pukaskwa,8a37826a-41a2-4a33-9329-13e3fd5cc112,Pitcher's Thistle - Survey Data- Pukaskwa,105986
+pc,f236214e-4d1b-40c6-8ecc-d62664f5c2b0,Coastal Plants - Pukaskwa,fd141149-6a85-4619-a17d-ee0653b5ef90,Pitcher's Thistle - Restoration Data- Pukaskwa,6965
+pc,f268ba62-7ce6-445e-92c3-0e32571d3777,Condition of Built Heritage Assets ,c984646f-7bec-4a4f-a1c2-60093bbb82e8,Built Heritage Assets - Condition 2021-2022,262155
+cfia-acia,f29d633b-8709-4ee1-8853-399e0f005844,CFIA-Undeclared gluten in legume/pulse products - 2021-2022,8e066300-4c7a-4bfc-ad25-debca1e13cce,CFIA-Undeclared gluten in legume/pulse products - 2021-2022,46612
+pc,f3288c4d-a273-440e-8693-268ce876fec1,Parks Canada attendance 2023_24,7f58c813-9a00-4223-b142-ef9aa9099681,Parks Canada attendance 2023-24,5824
+pc,f3288c4d-a273-440e-8693-268ce876fec1,Parks Canada attendance 2023_24,b8211fa1-d2a0-4efa-aa32-cc8501024622,Parks Canada attendance 2023-24,6390
+pc,f3616527-0c5d-4b01-baad-5aef0e3e86c8,River Otter - Kouchibouguac,065b3afb-084f-4af7-b753-c7635ebcbc2c,River Otter - Kouchibouguac - Data,3542
+pc,f3616527-0c5d-4b01-baad-5aef0e3e86c8,River Otter - Kouchibouguac,d8f57ccd-7f4e-4f11-9f3a-442cb6e180ea,River Otter - Kouchibouguac - Metadata,1495
+cfia-acia,f3bf17dc-1fce-4e05-b682-930054de5566,Food Microbiology - Targeted Surveys - 2014 - 2018 Bacterial Pathogens in Dried Herbs and Tea - Final Report,f4f21610-d022-4878-a380-d2f08c5c7839,Food Microbiology - Targeted Surveys - 2014 - 2018 Bacterial Pathogens in Dried Herbs and Tea - Final Report,5288214
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",a691dd5d-c3e4-4ab5-b23c-2c190f83a697,encounters,83924
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",709cad6e-8da0-4dfe-a858-680506e4b0e3,encounters,85191
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",b91cbeb4-18a1-4b81-88a8-a46f40efa4f5,event,70107
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",5addb7e1-818a-4d2d-bd46-6f3bf1b445ce,event,69687
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",2145143e-e3fa-4e4f-a8df-c8efefc7becc,hunting-team,24787
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",d880985c-9796-4411-b7eb-b8def82e4a2f,hunting-team,24058
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",6990e632-bc99-4805-aa8c-36fd23c5f8f3,islands,390
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",aa199a45-f7ac-4db9-833f-70cc9a11b57b,islands,343
+pc,f41943b1-fbd7-47ec-8311-d6a0ab379d25,"Dataset: Relative efficiency of hunting methods during an incomplete Sitka black-tailed deer (Odocoileus hemionus sitkensis Merriam, 1898) eradication on Haida Gwaii, Canada",d8924c9b-7b2c-4061-87ae-2ac9dc2bbaf1,Data Dictionary,7739
+pc,f47af768-99d7-419f-869b-85f0bfbce2a4,CABIN - Benthic Invertebrates - Kouchibouguac,71b9cc0e-c0d5-4616-95c9-8592ed3df50c,CABIN Benthic Invertebrates - Kouchibouguac - Summary metadata,1160
+ssc-spc,f516ebfa-4e5d-4bc9-800e-03ade299a94f,Fixed Telephony,7332f362-1cc0-4b2a-a46d-79fe0c81e925,Fixed Telephony,252040
+ssc-spc,f516ebfa-4e5d-4bc9-800e-03ade299a94f,Fixed Telephony,166979cf-2b5a-4815-a635-e57d32448fc2,Fixed Telephony,275341
+atssc-scdata,f577b65b-f33b-4de2-ac8b-91ff3f212491,2019-20 Departmental Results Report  - Results at a glance and operating context,a35e6ece-01df-4c05-9907-cd5c52c6d612,Results at a glance,100
+pc,f586e5a7-671b-4a8f-8dbe-5053a684fd37, Frog Abundance - Georgian Bay Islands,1355610a-ab2f-4f4e-8a02-7ca554a6fae3, Frog Abundance - Georgian Bay Islands,810057
+pc,f586e5a7-671b-4a8f-8dbe-5053a684fd37, Frog Abundance - Georgian Bay Islands,3e5fa781-1ada-42dd-bb15-3ac4c42aa360,Frog Abundance,842
+tbs-sct,f5933709-4775-4ea0-ade7-499faa29b7ed,Language names and codes,dc4f7d62-87a4-42a7-bbd7-e757c482e57d,Reference Data ,187125
+tbs-sct,f5933709-4775-4ea0-ade7-499faa29b7ed,Language names and codes,48ad6473-f587-4678-a285-a3f843ef1c1c,Name Index,214452
+ssc-spc,f5ac36cd-1fb4-4e97-9ee2-72552979387b,Email Services Metrics,ae23c6f2-e165-4345-ae7f-e5036ed0e3f3,Email Services Metrics 2019-2020,15841
+ssc-spc,f5ac36cd-1fb4-4e97-9ee2-72552979387b,Email Services Metrics,90fb7ee5-9f59-4871-955d-f0dd219e88e9,Email Services Metrics 2019-2020,18778
+ssc-spc,f5ac36cd-1fb4-4e97-9ee2-72552979387b,Email Services Metrics,e385d83a-7291-45e0-a57a-3dac33581b4e,Email Services Metrics 2020-2021,23235
+ssc-spc,f5ac36cd-1fb4-4e97-9ee2-72552979387b,Email Services Metrics,d68355f6-6192-4d54-8baa-34e934f71e38,Email Services Metrics 2020-2021,23262
+ssc-spc,f5ac36cd-1fb4-4e97-9ee2-72552979387b,Email Services Metrics,7d0d7edd-97af-4285-bcf1-f4cf889fc845,Email Services Metrics 2021-2022,18997
+ssc-spc,f5ac36cd-1fb4-4e97-9ee2-72552979387b,Email Services Metrics,b183dd54-ff33-43df-bc9c-58e75d128784,Email Services Metrics 2021-2022,22959
+pc,f5b0dfc3-89d8-4b9e-a23b-6ced6b9e77c4,Canadian Aquatic Biomonitoring Network - Mount Revelstoke,346c1855-0cc7-459b-bf29-1fa6f9df2f3b,Canadian Aquatic Biomonitoring Network - Mount Revelstoke,1452
+pc,f5b0dfc3-89d8-4b9e-a23b-6ced6b9e77c4,Canadian Aquatic Biomonitoring Network - Mount Revelstoke,dd007121-0a22-4b61-8fc7-ea7d3f326d2c,Canadian Aquatic Biomonitoring Network - Mount Revelstoke - Data Dictionary,617
+pc,f5c897f1-f971-4219-98f5-6ce9e089f7e7,Elk Abundance - Riding Mountain,92ed17a0-5385-4437-8ae2-463fbdf74aa6,Elk Abundance - Riding Mountain,282
+dnd-mdn,f763577c-b501-460c-935d-85135f41a30c,National Defence Program Inventory (PI),b9483810-e9a2-4553-a8c2-1b03f2374324,National Defence Program Inventory (PI),47605
+pc,f8c897e9-38da-48b9-af84-104dc3926ada,Water Quality - Jasper,1d208a1e-a62e-40f7-93dd-7c820adf12f8,Water Quality - Jasper,29455
+pc,f8c897e9-38da-48b9-af84-104dc3926ada,Water Quality - Jasper,56c833b7-1ed2-4f0e-b889-9606ec35211e,Water Quality - Jasper - data dictionary,2976
+pc,f8da9400-be08-4a0a-98e9-e4b10af561e2,Fire Cycle - Nahanni,a4fcaca0-9740-470f-92b4-c740f432d9d8,Fire Cycle - Nahanni - Data,3058
+pc,f8da9400-be08-4a0a-98e9-e4b10af561e2,Fire Cycle - Nahanni,566dd340-25b2-44c8-a6c6-be8a8218a095,Fire Cycle - Nahanni - Data dictionary,951
+cfia-acia,f932316e-6b74-4fb4-a6ce-43ea6a2aa4c3,Meat Species Substitution Summary Data ,89156e4a-2639-4094-bc82-b43a4254d588,Meat Species Substitution Summary Data - 2022-2023,11441
+pc,fa65a9e5-f8ac-4b79-a0f3-3e3b1c7fdacd,Rock ptarmigan population size - Gros Morne,4ca4422d-7d10-4fd8-8745-7991628d3238,Rock ptarmigan population size - Gros Morne - Data,1964
+pc,fa65a9e5-f8ac-4b79-a0f3-3e3b1c7fdacd,Rock ptarmigan population size - Gros Morne,e7bc6800-f355-4ccf-860a-70cee5eea509,Rock ptarmigan population size - Gros Morne - Data dictionary ,1496
+pc,fa855254-cb18-4156-83b6-70b693f2990c,Stream Benthic Invertebrate Richness - Gwaii Haanas,56042a58-68c6-4606-8e00-49c4bb611b61,Stream Benthic Invertebrate Richness - Gwaii Haanas,11803
+pc,fa855254-cb18-4156-83b6-70b693f2990c,Stream Benthic Invertebrate Richness - Gwaii Haanas,1088b710-3d0c-4976-9424-3218eb1daa15,Stream Benthic Invertebrate Richness - Gwaii Haanas - Data Dictionary,1891
+cfia-acia,fab3225c-db68-4867-96d3-d33db0b7fc55,"Food Microbiology – Targeted Surveys – Final Report – Bacterial Pathogens and Indicators in Ready-to-eat Non-Soy Plant-based Meat Alternatives - April 1, 2020 to March 31, 2023",385025b0-9a2b-4107-aaa9-b71407411b85,"Food Microbiology – Targeted Surveys – Final Report – Bacterial Pathogens and Indicators in Ready-to-eat Non-Soy Plant-based Meat Alternatives - April 1, 2020 to March 31, 2023",2052122
+pc,faec23af-498a-459c-be86-d34562581ab1,Plant Productivity and Growing Season Change - Torngat Mountains,9a941a8c-052a-4a6d-9d5f-c63b633052b2,Plant Productivity and Growing Season Change - Torngat Mountains,1144
+atssc-scdata,fb55a0a8-4451-43d2-ab4f-819c34a00772,2018-19 Departmental Results Report - Results,1afc1675-cbbb-4bcc-be7d-88860fba25bd,Results at a glance,100
+dnd-mdn,fb739176-4bca-4a24-9046-5bb164041e15,Standardized Mortality Ratios for Suicide in the CAF Regular Force Male Population by History of Deployment,57b041d4-5183-4263-abe8-696f35bb0c59,Standardized Mortality Ratios for Suicide in the CAF Regular Force Male Population by History of Deployment: 1995-2012,332
+hc-sc,fba587c8-5b3f-4b5e-9461-734a497bc35e,Indoor Air Carbon Monoxide (CO) summary statistics,eb99e914-49ed-4fe4-aa52-70b14f0e13c1,Indoor Carbon Monoxide (CO) summary statistics,3128
+hc-sc,fba587c8-5b3f-4b5e-9461-734a497bc35e,Indoor Air Carbon Monoxide (CO) summary statistics,2bfa39df-936e-4625-93a7-7c15accd2a11,Indoor Carbon Monoxide (CO) summary statistics,3326
+hc-sc,fba587c8-5b3f-4b5e-9461-734a497bc35e,Indoor Air Carbon Monoxide (CO) summary statistics,bbc4a7b4-1a02-4fbe-9843-1c52e5d38dde,Indoor Carbon Monoxide (CO) Data Dictionary,692
+hc-sc,fba587c8-5b3f-4b5e-9461-734a497bc35e,Indoor Air Carbon Monoxide (CO) summary statistics,43e36719-b107-4c3d-a9a0-e15acb667900,Indoor Carbon Monoxide (CO) Data Dictionary,904
+pc,fbb9428a-26f6-47ef-9016-b800b429bad8,Water Quality - Tuktut,6b76f15c-a8ab-4713-b1f9-a0f36cd1b559,Water Quality - Tuktut -  HRE - Dissolved Metals - 2000-2017 - data - 1,4647
+pc,fbb9428a-26f6-47ef-9016-b800b429bad8,Water Quality - Tuktut,08e5d056-7e36-47c6-bf1e-5c23511adc8a,Water Quality - Tuktut -  HRE - Total Metals - 2000-2017 - data - 2,6071
+pc,fbb9428a-26f6-47ef-9016-b800b429bad8,Water Quality - Tuktut,f44dbeec-f29e-4edd-b156-04ba710c9b46,Water Quality - Tuktut -  LHR- Dissolved Metals - 2000-2017 - data -3,5249
+pc,fbb9428a-26f6-47ef-9016-b800b429bad8,Water Quality - Tuktut,5a79c67e-9dfc-4e92-95c0-5d7494b51306,Water Quality - Tuktut -  LHR - Total Metals - 2000-2017 - data - 4,6599
+pc,fbb9428a-26f6-47ef-9016-b800b429bad8,Water Quality - Tuktut,bf96988d-014e-48fd-92d3-a0bc0f0ba44c,"Water Quality - Tuktut -  LHR - Nutrients, Physicals ,and Major Ions - 1998-2017 - data - 5",6075
+pc,fbb9428a-26f6-47ef-9016-b800b429bad8,Water Quality - Tuktut,6bb26ba7-fbcb-4444-8bb4-5fd057935102,"Water Quality - Tuktut -  HRE - Nutrients, Physicals ,and Major Ions - 1998-2017 - data - 6",5535
+pc,fbb9428a-26f6-47ef-9016-b800b429bad8,Water Quality - Tuktut,045c4ddf-0112-45ef-b9a9-eb14c90f89b0,Water Quality - Tuktut  - 1998-2017 - data dictionary,979
+psc-cfp,fc0ea6c8-11e7-4252-8ac1-38232424e5fe,Investigations by the Public Service Commission,666a8905-c7bb-4407-b5f8-84b5bff0f15a,Public Service Investigations until 30-09-2024,328859
+ssc-spc,fc540275-898d-4632-a4d8-5356faf6275b,Cost of procurement per each $100 of contracts awarded ,5fa3ada7-788e-4c69-a622-27b5870b1993,Cost of procurement per each $100 of contracts awarded ,321
+ssc-spc,fc540275-898d-4632-a4d8-5356faf6275b,Cost of procurement per each $100 of contracts awarded ,36c92e8a-2e8e-42ea-8d04-a8029a64b927,Cost of procurement per each $100 of contracts awarded ,336
+tbs-sct,fc6ba156-a167-4abd-b172-d1293efebe55,GC InfoBase - Authorities and Expenditures,3fde453f-e3b7-4fa4-a282-f195bf872f9e,Authorities and Expenditures by Vote (Annual),648257
+tbs-sct,fc6ba156-a167-4abd-b172-d1293efebe55,GC InfoBase - Authorities and Expenditures,a11759a7-40e8-477e-905d-d08d33f04a88,Authorities and Expenditures by Vote (Annual),758999
+tbs-sct,fc6ba156-a167-4abd-b172-d1293efebe55,GC InfoBase - Authorities and Expenditures,2d6af7ca-0063-4ce8-a50f-1a273adf196e,Estimates - Expenditure Authorities by Vote (Sub-annual),381705
+tbs-sct,fc6ba156-a167-4abd-b172-d1293efebe55,GC InfoBase - Authorities and Expenditures,bf168593-ebef-4f9c-97b3-6336aea96aa2,Estimates - Expenditure Authorities by Vote (Sub-annual),485046
+tbs-sct,fc6ba156-a167-4abd-b172-d1293efebe55,GC InfoBase - Authorities and Expenditures,83004889-d936-406c-87e1-6707b02e9769,Estimates - Statutory Forecasts,396342
+tbs-sct,fc6ba156-a167-4abd-b172-d1293efebe55,GC InfoBase - Authorities and Expenditures,c21665b9-6805-44b6-afdb-92eb1cd212d4,Estimates - Statutory Forecasts,527807
+pc,fc755473-e2cc-4c1b-a7b6-a8637d2bfa2e,Whitebark Pine - Glacier,51fa376d-cd43-46d1-af5d-a838610120e4,Whitebark Pine - Glacier,2114
+pc,fc755473-e2cc-4c1b-a7b6-a8637d2bfa2e,Whitebark Pine - Glacier,ade2cad9-94ae-42a6-af1a-a94cc642f3e0,Whitebark Pine - Data Dictionary,413
+pc,fca3a8b2-bc4f-45df-b1f3-75d20e9ef6d7,Permafrost active layer depth - Torngat Mountains,0819e64a-60de-4952-97bf-39e59199df92,Permafrost active layer depth - Torngat Mountains,1157258
+pc,fcf1837f-47d2-49d7-b4c4-cc11529b43fa,Benthic invertebrates - Kejimkujik,ea3b7cc1-d0c2-44d9-bf6b-25425359bfac,Benthic Invertebrates - Kejimkujik - Summary Data - 1,2695
+pc,fcf1837f-47d2-49d7-b4c4-cc11529b43fa,Benthic invertebrates - Kejimkujik,79037595-2f84-4dc9-8462-5530dcb228e1,Benthic Invertebrates - Kejimkujik - Data Dictionary,2050
+cfia-acia,fd506849-f400-4a3f-8a0f-63e73794fd57,"Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens in Mechanically Tenderized Beef Steaks - April 1, 2018 to March 31, 2019",7cd12487-b6ef-4ee8-9fed-b76f3f4c2e78,"Food Microbiology - Targeted Surveys - Final Report - Bacterial Pathogens in Mechanically Tenderized Beef Steaks - April 1, 2018 to March 31, 2019",732861
+pc,fe2441a6-8ae4-4884-b181-cd7ec53bd842,Fish Communities - Forillon,f2edabeb-0621-4790-bdac-a583fe8212aa,Situation_fish_communities - Forillon - Data,325148
+pc,fe2441a6-8ae4-4884-b181-cd7ec53bd842,Fish Communities - Forillon,050cbf38-be04-4286-addd-f23e2bdfcecd,Situation_fish_communities - Forillon - Data dictionary,2038
+pc,fe4410d7-07ae-4f4a-abda-0441fb215503,Forest bird biodiversity in winter - Gros Morne,f6ba0906-3211-45f9-9437-dda2bc159eaa,Forest bird biodiversity in winter - Gros Morne - Data ,155031
+pc,fe4410d7-07ae-4f4a-abda-0441fb215503,Forest bird biodiversity in winter - Gros Morne,c01cc479-8553-4670-852e-fbd811574e4a,Forest bird biodiversity in winter - Gros Morne - Data dictionary ,4141
+cbsa-asfc,fe8020ad-51a1-4752-a509-b011a48411a8,Border Wait Times – Air Mode,7d4d8f73-1c3a-4102-b043-ec156029fef7,Border Wait Times – Air Mode,26812
+cbsa-asfc,fe8020ad-51a1-4752-a509-b011a48411a8,Border Wait Times – Air Mode,8a440173-b06f-45b0-9aa5-7b549dd4adda,Border Wait Times – Air Mode,26783
+pc,febeb854-6bee-4bac-a071-1c5d7a9d6af9,Colonial Waterbirds - Fathom Five,9823a241-9d3f-46c5-901a-f28c6f9b9dc4,Colonial Waterbirds - Fathom Five,17027
+pc,febeb854-6bee-4bac-a071-1c5d7a9d6af9,Colonial Waterbirds - Fathom Five,e1c8d916-5499-4c23-94aa-9854aa6b01e5,Colonial Waterbirds - Fathom Five - Data Dictonary,1219
+pc,ff776da3-ab17-43f2-af57-fa49aaabafb3,Parks Canada performance data (support) 2023_24,d2d0b65f-2773-4314-9641-409235ca6640,Parks Canada performance data (support) 2023_24,180447
+pc,ff776da3-ab17-43f2-af57-fa49aaabafb3,Parks Canada performance data (support) 2023_24,452ce673-5130-420d-a79a-baa2d5e45f61,Parks Canada performance data (support) 2023_24,180426

--- a/datastore_tracker/ds_tracker.py
+++ b/datastore_tracker/ds_tracker.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+import requests
+import gzip
+import os
+import time
+import pandas as pd
+from datetime import datetime
+
+# Optional faster JSON parsing
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+def pretty_bytes(num_bytes):
+    """
+    Convert a file size in bytes into a human-readable string.
+    Equivalent to R's prettyunits::pretty_bytes().
+    """
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']:
+        if abs(num_bytes) < 1024.0:
+            return f"{num_bytes:3.1f}{unit}"
+        num_bytes /= 1024.0
+    return f"{num_bytes:.1f}YB"
+
+
+def main():
+    # -------------------------------------------------------------------------
+    # 1. Download the compressed JSONL file
+    # -------------------------------------------------------------------------
+    url = "https://open.canada.ca/static/od-do-canada.jsonl.gz"
+    print("Downloading file...")
+    start_download = time.time()
+    r = requests.get(url, stream=True)
+    with open("od-do-canada.jsonl.gz", "wb") as f:
+        for chunk in r.iter_content(chunk_size=8192):
+            f.write(chunk)
+    end_download = time.time()
+    print(f"Download complete in {end_download - start_download:.2f} seconds.")
+
+    # -------------------------------------------------------------------------
+    # 2. Decompress the file
+    # -------------------------------------------------------------------------
+    print("Unzipping file...")
+    start_unzip = time.time()
+    with gzip.open("od-do-canada.jsonl.gz", "rb") as f_in, open("od-do-canada.jsonl", "wb") as f_out:
+        f_out.write(f_in.read())
+    os.remove("od-do-canada.jsonl.gz")
+    end_unzip = time.time()
+    print(f"Unzip complete in {end_unzip - start_unzip:.2f} seconds.")
+
+    # -------------------------------------------------------------------------
+    # 3. Parse each line and build a list of dictionaries
+    # -------------------------------------------------------------------------
+    print("Parsing JSON lines...")
+    start_parse = time.time()
+
+    list_of_dicts = []
+
+    with open("od-do-canada.jsonl", "r", encoding="utf-8") as f:
+        for line in f:
+            tmp_data = json.loads(line)
+            tmp_res = tmp_data.get("resources", [])
+
+            # Skip if no resources
+            if not tmp_res:
+                continue
+
+            # For each resource, store relevant row if datastore_active != FALSE
+            for resource in tmp_res:
+                if resource.get("datastore_active", False) != False:
+                    row_dict = {
+                        "owner":         tmp_data.get("organization", {}).get("name", ""),
+                        "package_id":    resource.get("package_id", ""),
+                        "dataset_name":  tmp_data.get("title", ""),
+                        "resource_id":   resource.get("id", ""),
+                        "resource_name": resource.get("name", ""),
+                        "size":          resource.get("size", "")
+                    }
+                    list_of_dicts.append(row_dict)
+
+    end_parse = time.time()
+    print(f"Parsing complete in {end_parse - start_parse:.2f} seconds.")
+
+    # -------------------------------------------------------------------------
+    # 4. Create a DataFrame from the collected dictionaries
+    # -------------------------------------------------------------------------
+    start_df = time.time()
+    list_of_res = pd.DataFrame(list_of_dicts)
+    end_df = time.time()
+    print(f"DataFrame creation complete in {end_df - start_df:.2f} seconds.")
+
+    # -------------------------------------------------------------------------
+    # 5. Summaries (unique counts, date/time, etc.)
+    # -------------------------------------------------------------------------
+    # Use YYYY-MM-DD format
+    date_str = datetime.now().strftime('%Y-%m-%d')
+    num_dept = list_of_res["owner"].nunique()
+    num_datasets = list_of_res["package_id"].nunique()
+    num_res = list_of_res["resource_id"].nunique()
+
+    # -------------------------------------------------------------------------
+    # 6. Fetch datastore size from CKAN API
+    # -------------------------------------------------------------------------
+    ds_url = "https://open.canada.ca/data/en/api/3/action/datastore_info?id=3c911562-c541-463f-8cd4-490182cd57f9"
+    ds_resp = requests.get(ds_url)
+    ds_data = ds_resp.json()
+    ds_size_bytes = ds_data["result"]["meta"]["db_size"]
+    ds_size_readable = pretty_bytes(ds_size_bytes)
+
+    # -------------------------------------------------------------------------
+    # 7. Build a DataFrame for DS_num_tracker (single row)
+    # -------------------------------------------------------------------------
+    DS_num_tracker_df = pd.DataFrame([{
+        "date": date_str,
+        "num_dept": num_dept,
+        "num_datasets": num_datasets,
+        "num_res": num_res,
+        "ds_size_readable": ds_size_readable
+    }])
+
+    # -------------------------------------------------------------------------
+    # 8. Append the new row to DS_num_tracker.csv, ensuring the newest row is on top
+    # -------------------------------------------------------------------------
+    csv_path = "DS_num_tracker.csv"
+
+    if os.path.exists(csv_path):
+        # Read existing CSV
+        old_df = pd.read_csv(csv_path)
+
+        # Append new row (concat) then sort by date descending
+        combined_df = pd.concat([DS_num_tracker_df, old_df], ignore_index=True)
+
+        # Convert 'date' column to datetime so we can sort properly
+        combined_df["date"] = pd.to_datetime(combined_df["date"], format="%Y-%m-%d", errors="coerce")
+        combined_df.sort_values(by="date", ascending=False, inplace=True)
+
+        # Re-format date back to string if needed
+        combined_df["date"] = combined_df["date"].dt.strftime("%Y-%m-%d")
+
+        # Write to CSV
+        combined_df.to_csv(csv_path, index=False)
+    else:
+        # If no CSV exists, just write the single row
+        DS_num_tracker_df.to_csv(csv_path, index=False)
+
+    # -------------------------------------------------------------------------
+    # 9. (Optional) Save resources list to CSV if desired
+    # -------------------------------------------------------------------------
+    list_of_res.to_csv("ds-resources.csv", index=False)
+
+    # -------------------------------------------------------------------------
+    # 10. Print output (useful for debugging or GH Action logs)
+    # -------------------------------------------------------------------------
+    print("=== DS_num_tracker (latest) ===")
+    print(DS_num_tracker_df.to_string(index=False))
+    print("\nCSV appended (or created) successfully.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
 * `datastore_tracker/ds-resources.csv` keeps the list of datastore resources tracked. Adds size column for resources
 * `datastore_tracker/DS_num_tracker.csv` adds:
    * date - 2024-12-27
    * num_dept - 36
    * num_datasets - 779 
    * num_res - 2251
    * ds_size_readable - 111.8GB
 * Based on the changes in https://open-data.github.io/stack-release-notes/#2024.12.17 I want to monitor the DS growth more closely in the near term. 